### PR TITLE
Fixed sliders not being themed

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -20,7 +20,7 @@ stage {
   border-width: 0;
   padding: 4px 32px; }
   .button:focus {
-    color: #8fbcbb;
+    color: #ECCF95;
     text-shadow: 0 1px black;
     icon-shadow: 0 1px black;
     box-shadow: none;
@@ -33,7 +33,7 @@ stage {
     text-shadow: none;
     icon-shadow: none; }
   .button:active {
-    color: #8fbcbb;
+    color: #ECCF95;
     background-color: rgba(46, 52, 64, 0.88);
     border: none;
     text-shadow: none;
@@ -144,7 +144,7 @@ StScrollBar {
   -barlevel-height: 0.3em;
   -barlevel-background-color: #4e586d;
   -barlevel-border-color: black;
-  -barlevel-active-background-color: #8fbcbb;
+  -barlevel-active-background-color: #ECCF95;
   -barlevel-active-border-color: #a3be8c;
   -barlevel-border-width: 0;
   -barlevel-handle-radius: 6px; }
@@ -436,7 +436,7 @@ StScrollBar {
   border: 1px solid #d8dee9;
   border-radius: 12px; }
   .audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
-    background-color: #8fbcbb; }
+    background-color: #ECCF95; }
 
 .audio-selection-device-box {
   padding: 20px;
@@ -717,7 +717,7 @@ StScrollBar {
       background: rgba(50, 57, 70, 0.65);
       color: #f9fafb; }
     #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
-      background: #8fbcbb;
+      background: #81A1C1;
       box-shadow: inset 0 -2px 0px #9fc6c5;
       color: #f9fafb;
       text-shadow: 0px 0px 2px rgba(0, 0, 0, 0.9); }
@@ -877,10 +877,10 @@ StScrollBar {
   margin: 2px;
   border-radius: 1.4em; }
   .calendar-day-base:hover, .calendar-day-base:focus {
-    background-color: rgba(57, 64, 79, 0.93); }
+    background-color: rgba(57, 64, 79, 1); }
   .calendar-day-base:active, .calendar-day-base:selected {
     color: white;
-    background-color: #8fbcbb;
+    background-color: #F28C6D;
     border-color: transparent; }
   .calendar-day-base.calendar-day-heading {
     color: #58709d;

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -141,13 +141,13 @@ StScrollBar {
   height: 1em;
   color: #fefefe;
   border-color: black;
-  -slider-height: 0.3em;
-  -slider-background-color: #4e586d;
-  -slider-border-color: black;
-  -slider-active-background-color: #8fbcbb;
-  -slider-active-border-color: #a3be8c;
-  -slider-border-width: 0;
-  -slider-handle-radius: 6px; }
+  -barlevel-height: 0.3em;
+  -barlevel-background-color: #4e586d;
+  -barlevel-border-color: black;
+  -barlevel-active-background-color: #8fbcbb;
+  -barlevel-active-border-color: #a3be8c;
+  -barlevel-border-width: 0;
+  -barlevel-handle-radius: 6px; }
 
 /* Check Boxes */
 .check-box StBoxLayout {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nordic",
+  "name": "frost",
   "version": "1.0.0",
   "description": "Dark theme created using the awesome Nord color pallete",
   "main": "index.js",
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/EliverLara/Nordic.git"
+    "url": "git+https://github.com/Nequo/Nordic.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/EliverLara/Nordic/issues"
+    "url": "https://github.com/EliverLara/Nequo/issues"
   },
-  "homepage": "https://github.com/EliverLara/Nordic#readme",
+  "homepage": "https://github.com/EliverLara/Nequo#readme",
   "dependencies": {
     "gulp": "^4.0.0",
     "gulp-exec": "^2.1.3",


### PR DESCRIPTION
In gnome 3.30, the css name for the gnome shell slider properties changed to bar level. I applied those fixes and it works for me on arch with the latest gnome shell.