### PR TITLE
Change Alternate color for NordDarker

### DIFF
--- a/kde/colorschemes/NordicDarker.colors
+++ b/kde/colorschemes/NordicDarker.colors
@@ -61,7 +61,7 @@ ForegroundPositive=163,190,140
 ForegroundVisited=82,148,226
 
 [Colors:View]
-BackgroundAlternate=20,26,33
+BackgroundAlternate=46,52,64
 BackgroundNormal=59,66,82
 DecorationFocus=76,86,106
 DecorationHover=76,86,106


### PR DESCRIPTION
With nord darker the alternate color is a little too dark and makes the alternating look weird.

Without change:
![1](https://user-images.githubusercontent.com/37805707/121822244-5c472e80-cc9e-11eb-8d3b-e848cd89b69c.png)

With change:
![2](https://user-images.githubusercontent.com/37805707/121822248-62d5a600-cc9e-11eb-923c-72ecc0215a90.png)

This change makes the alternate color look more subtle