### PR TITLE
gnome-shell: Implement Nordic styles for new pop_os 21.04 cosmic visual elements 

### DIFF
--- a/gnome-shell/_common.scss
+++ b/gnome-shell/_common.scss
@@ -1318,6 +1318,10 @@ StScrollBar {
   spacing: 24px; //
 }
 
+#overview.cosmic-solid-bg {
+  background-color: $topbar_bg_color !important;
+}
+
 .overview-controls {
   padding-bottom: 32px;
 }

--- a/gnome-shell/_cosmic.scss
+++ b/gnome-shell/_cosmic.scss
@@ -1,0 +1,32 @@
+@import '../gtk-3.0/_nord';
+
+/* Pop_OS COSMIC Widget styling. */
+/* Pop_OS COSMIC Dock styling, append !important to any changed rules */
+.cosmic-dock #dock {
+  border-radius: 12px 12px 12px 12px !important;
+  border: 0 !important;
+  background-color: $nord0;
+  margin: 4px !important; 
+}
+
+.cosmic-dock.extended #dock {
+  border-radius: 0px !important;
+  margin: 0 !important; }
+
+.cosmic-dock.extended.side #dock {
+  border-top-width: 0 !important;
+  border-bottom-width: 0 !important; }
+
+.cosmic-dock.extended.side.left #dock {
+  border-left-width: 0 !important; }
+
+.cosmic-dock.extended.side.right #dock {
+  border-right-width: 0 !important; }
+
+.cosmic-dock.extended.bottom #dock {
+  border-bottom-width: 0 !important;
+  border-left-width: 0 !important;
+  border-right-width: 0 !important; }
+
+.cosmic-dock .app-well-app:hover .overview-icon, .cosmic-dock .app-well-app:focus .overview-icon, .cosmic-dock .app-well-app:selected .overview-icon {
+  border-radius: 11px; }

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -4,7 +4,8 @@
 /* GLOBALS */
 stage {
   font-size: 10pt;
-  color: #d8dee9; }
+  color: #d8dee9;
+}
 
 /* WIDGETS */
 /* Buttons */
@@ -17,32 +18,37 @@ stage {
   icon-shadow: 0 1px black;
   border-radius: 4px;
   border-width: 0;
-  padding: 4px 32px; }
-  .button:focus {
-    color: #4c566a;
-    text-shadow: 0 1px black;
-    icon-shadow: 0 1px black;
-    box-shadow: none;
-    border: 1px solid #1f232b; }
-  .button:insensitive {
-    color: #838995;
-    background-color: rgba(64, 70, 82, 0.66);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-    border: none;
-    text-shadow: none;
-    icon-shadow: none; }
-  .button:active {
-    color: #4c566a;
-    background-color: rgba(46, 52, 64, 0.95);
-    border: 1px solid #1f232b;
-    text-shadow: none;
-    icon-shadow: none; }
-  .button:hover {
-    color: #4c566a;
-    background-color: rgba(50, 57, 70, 0.95);
-    border: 1px solid #1f232b;
-    text-shadow: 0 1px black;
-    icon-shadow: 0 1px black; }
+  padding: 4px 32px;
+}
+.button:focus {
+  color: #4c566a;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+  box-shadow: none;
+  border: 1px solid #1f232b;
+}
+.button:insensitive {
+  color: #838995;
+  background-color: rgba(64, 70, 82, 0.66);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  border: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+.button:active {
+  color: #4c566a;
+  background-color: rgba(46, 52, 64, 0.95);
+  border: 1px solid #1f232b;
+  text-shadow: none;
+  icon-shadow: none;
+}
+.button:hover {
+  color: #4c566a;
+  background-color: rgba(50, 57, 70, 0.95);
+  border: 1px solid #1f232b;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+}
 
 .modal-dialog-linked-button {
   padding: 10px;
@@ -51,44 +57,53 @@ stage {
   background: #232831;
   text-shadow: none;
   icon-shadow: none;
-  box-shadow: none; }
-  .modal-dialog-linked-button:insensitive {
-    color: #838995;
-    background-color: rgba(64, 70, 82, 0.66);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-    border: none;
-    text-shadow: none;
-    icon-shadow: none; }
-  .modal-dialog-linked-button:active {
-    color: #4c566a;
-    background-color: rgba(46, 52, 64, 0.95);
-    border: 1px solid #1f232b;
-    text-shadow: none;
-    icon-shadow: none; }
-  .modal-dialog-linked-button:focus {
-    color: #4c566a;
-    text-shadow: 0 1px black;
-    icon-shadow: 0 1px black;
-    box-shadow: none;
-    border: 1px solid #1f232b; }
-    .modal-dialog-linked-button:focus:hover {
-      color: #4c566a;
-      text-shadow: 0 1px black;
-      icon-shadow: 0 1px black;
-      box-shadow: none;
-      border: 1px solid #1f232b; }
-  .modal-dialog-linked-button:hover {
-    color: #4c566a;
-    background-color: rgba(50, 57, 70, 0.95);
-    border: 1px solid #1f232b;
-    text-shadow: 0 1px black;
-    icon-shadow: 0 1px black; }
-  .modal-dialog-linked-button:first-child {
-    border-radius: 0px 0px 0px 2px; }
-  .modal-dialog-linked-button:last-child {
-    border-radius: 0px 0px 2px 0px; }
-  .modal-dialog-linked-button:first-child:last-child {
-    border-radius: 0px 0px 2px 2px; }
+  box-shadow: none;
+}
+.modal-dialog-linked-button:insensitive {
+  color: #838995;
+  background-color: rgba(64, 70, 82, 0.66);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  border: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
+.modal-dialog-linked-button:active {
+  color: #4c566a;
+  background-color: rgba(46, 52, 64, 0.95);
+  border: 1px solid #1f232b;
+  text-shadow: none;
+  icon-shadow: none;
+}
+.modal-dialog-linked-button:focus {
+  color: #4c566a;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+  box-shadow: none;
+  border: 1px solid #1f232b;
+}
+.modal-dialog-linked-button:focus:hover {
+  color: #4c566a;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+  box-shadow: none;
+  border: 1px solid #1f232b;
+}
+.modal-dialog-linked-button:hover {
+  color: #4c566a;
+  background-color: rgba(50, 57, 70, 0.95);
+  border: 1px solid #1f232b;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+}
+.modal-dialog-linked-button:first-child {
+  border-radius: 0px 0px 0px 2px;
+}
+.modal-dialog-linked-button:last-child {
+  border-radius: 0px 0px 2px 0px;
+}
+.modal-dialog-linked-button:first-child:last-child {
+  border-radius: 0px 0px 2px 2px;
+}
 
 /* Entries */
 StEntry {
@@ -100,40 +115,51 @@ StEntry {
   border-width: 0;
   color: #d8dee9;
   selection-background-color: #4c566a;
-  selected-color: #d8dee9; }
-  StEntry:focus {
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
-  StEntry:insensitive {
-    color: #838995;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
-  StEntry StIcon.capslock-warning {
-    icon-size: 16px;
-    warning-color: #c3674a;
-    padding: 0 4px; }
+  selected-color: #d8dee9;
+}
+StEntry:focus {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+StEntry:insensitive {
+  color: #838995;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+StEntry StIcon.capslock-warning {
+  icon-size: 16px;
+  warning-color: #c3674a;
+  padding: 0 4px;
+}
 
 /* Scrollbars */
 StScrollView.vfade {
-  -st-vfade-offset: 68px; }
-
+  -st-vfade-offset: 68px;
+}
 StScrollView.hfade {
-  -st-hfade-offset: 68px; }
+  -st-hfade-offset: 68px;
+}
 
 StScrollBar {
-  padding: 0; }
-  StScrollView StScrollBar {
-    min-width: 14px;
-    min-height: 14px; }
-  StScrollBar StBin#trough {
-    border-radius: 0;
-    background-color: transparent; }
-  StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
-    border-radius: 8px;
-    background-color: #505662;
-    margin: 3px; }
-    StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
-      background-color: #b6bcc7; }
-    StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
-      background-color: #4c566a; }
+  padding: 0;
+}
+StScrollView StScrollBar {
+  min-width: 14px;
+  min-height: 14px;
+}
+StScrollBar StBin#trough {
+  border-radius: 0;
+  background-color: transparent;
+}
+StScrollBar StButton#vhandle, StScrollBar StButton#hhandle {
+  border-radius: 8px;
+  background-color: #505662;
+  margin: 3px;
+}
+StScrollBar StButton#vhandle:hover, StScrollBar StButton#hhandle:hover {
+  background-color: #b6bcc7;
+}
+StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
+  background-color: #4c566a;
+}
 
 /* Slider */
 .slider {
@@ -156,384 +182,486 @@ StScrollBar {
   -barlevel-handle-radius: 6px;
   -barlevel-overdrive-color: #4c566a;
   -barlevel-overdrive-border-color: transparent;
-  -barlevel-overdrive-separator-width: 0px; }
+  -barlevel-overdrive-separator-width: 0px;
+}
 
 /* Check Boxes */
 .check-box StBoxLayout {
-  spacing: .8em; }
-
+  spacing: 0.8em;
+}
 .check-box StBin {
   width: 24px;
   height: 22px;
-  background-image: url("assets/checkbox-off.svg"); }
-
+  background-image: url("assets/checkbox-off.svg");
+}
 .check-box:focus, .check-box:hover StBin {
-  background-image: url("assets/checkbox-off-focused.svg"); }
-
+  background-image: url("assets/checkbox-off-focused.svg");
+}
 .check-box:checked StBin {
-  background-image: url("assets/checkbox.svg"); }
-
+  background-image: url("assets/checkbox.svg");
+}
 .check-box:focus:checked StBin {
-  background-image: url("assets/checkbox-focused.svg"); }
+  background-image: url("assets/checkbox-focused.svg");
+}
 
 /* Switches */
 .toggle-switch {
   width: 65px;
   height: 22px;
   background-size: contain;
-  background-image: url("assets/toggle-off.svg"); }
-  .toggle-switch:checked {
-    background-image: url("assets/toggle-on.svg"); }
+  background-image: url("assets/toggle-off.svg");
+}
+.toggle-switch:checked {
+  background-image: url("assets/toggle-on.svg");
+}
 
 .toggle-switch-us {
-  background-image: url("assets/toggle-off.svg"); }
-  .toggle-switch-us:checked {
-    background-image: url("assets/toggle-on.svg"); }
+  background-image: url("assets/toggle-off.svg");
+}
+.toggle-switch-us:checked {
+  background-image: url("assets/toggle-on.svg");
+}
 
 .toggle-switch-intl {
-  background-image: url("assets/toggle-off.svg"); }
-  .toggle-switch-intl:checked {
-    background-image: url("assets/toggle-on.svg"); }
+  background-image: url("assets/toggle-off.svg");
+}
+.toggle-switch-intl:checked {
+  background-image: url("assets/toggle-on.svg");
+}
 
 /* links */
 .shell-link {
-  color: #88c0d0; }
-  .shell-link:hover {
-    color: #add3de; }
+  color: #88c0d0;
+}
+.shell-link:hover {
+  color: #add3de;
+}
 
 /* Modal Dialogs */
 .headline {
-  font-size: 110%; }
+  font-size: 110%;
+}
 
 .lightbox {
-  background-color: black; }
+  background-color: black;
+}
 
 .flashspot {
-  background-color: white; }
+  background-color: white;
+}
 
 .modal-dialog {
   border: none;
   border-radius: 2px;
   color: #d8dee9;
   background-color: rgba(35, 40, 49, 0.95);
-  box-shadow: 0 2px 4px 2px rgba(0, 0, 0, 0.2); }
-  .modal-dialog .modal-dialog-content-box {
-    padding: 24px; }
-  .modal-dialog .run-dialog-entry {
-    width: 20em;
-    margin-bottom: 6px; }
-  .modal-dialog .run-dialog-error-box {
-    color: #b84f59;
-    padding-top: 16px;
-    spacing: 6px; }
-  .modal-dialog .run-dialog-button-box {
-    padding-top: 1em; }
-  .modal-dialog .run-dialog-label {
-    font-size: 11pt;
-    font-weight: bold;
-    color: #b7c2d7;
-    padding-bottom: .4em; }
-  .modal-dialog .run-dialog-description {
-    color: #d8dee9; }
+  box-shadow: 0 2px 4px 2px rgba(0, 0, 0, 0.2);
+}
+.modal-dialog .modal-dialog-content-box {
+  padding: 24px;
+}
+.modal-dialog .run-dialog-entry {
+  width: 20em;
+  margin-bottom: 6px;
+}
+.modal-dialog .run-dialog-error-box {
+  color: #b84f59;
+  padding-top: 16px;
+  spacing: 6px;
+}
+.modal-dialog .run-dialog-button-box {
+  padding-top: 1em;
+}
+.modal-dialog .run-dialog-label {
+  font-size: 11pt;
+  font-weight: bold;
+  color: #b7c2d7;
+  padding-bottom: 0.4em;
+}
+.modal-dialog .run-dialog-description {
+  color: #d8dee9;
+}
 
 .mount-dialog-subject,
 .end-session-dialog-subject {
-  font-size: 13pt; }
+  font-size: 13pt;
+}
 
 /* Message Dialog */
 .message-dialog-main-layout {
   padding: 12px 20px 0;
-  spacing: 12px; }
+  spacing: 12px;
+}
 
 .message-dialog-content {
   max-width: 28em;
-  spacing: 20px; }
+  spacing: 20px;
+}
 
 .message-dialog-icon {
   min-width: 48px;
-  icon-size: 48px; }
+  icon-size: 48px;
+}
 
 .message-dialog-title {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .message-dialog-subtitle {
   color: #58709d;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 /* End Session Dialog */
 .end-session-dialog {
   spacing: 42px;
-  border: none; }
-  .end-session-dialog .modal-dialog-linked-button:last-child {
-    background: #b84f59; }
-    .end-session-dialog .modal-dialog-linked-button:last-child:hover, .end-session-dialog .modal-dialog-linked-button:last-child:focus {
-      background: #bc5a63;
-      color: #fff; }
+  border: none;
+}
+.end-session-dialog .modal-dialog-linked-button:last-child {
+  background: #b84f59;
+}
+.end-session-dialog .modal-dialog-linked-button:last-child:hover, .end-session-dialog .modal-dialog-linked-button:last-child:focus {
+  background: #bc5a63;
+  color: #fff;
+}
 
 .end-session-dialog-list {
-  padding-top: 20px; }
+  padding-top: 20px;
+}
 
 .end-session-dialog-layout {
-  padding-left: 17px; }
-  .end-session-dialog-layout:rtl {
-    padding-right: 17px; }
+  padding-left: 17px;
+}
+.end-session-dialog-layout:rtl {
+  padding-right: 17px;
+}
 
 .end-session-dialog-description {
   width: 28em;
-  padding-bottom: 10px; }
-  .end-session-dialog-description:rtl {
-    text-align: right; }
+  padding-bottom: 10px;
+}
+.end-session-dialog-description:rtl {
+  text-align: right;
+}
 
 .end-session-dialog-warning {
   width: 28em;
   color: #c3674a;
-  padding-top: 6px; }
-  .end-session-dialog-warning:rtl {
-    text-align: right; }
+  padding-top: 6px;
+}
+.end-session-dialog-warning:rtl {
+  text-align: right;
+}
 
 .end-session-dialog-logout-icon {
   border-radius: 3px;
   width: 48px;
   height: 48px;
-  background-size: contain; }
+  background-size: contain;
+}
 
 .end-session-dialog-shutdown-icon {
   color: #b84f59;
   width: 48px;
-  height: 48px; }
+  height: 48px;
+}
 
 .end-session-dialog-inhibitor-layout {
   spacing: 16px;
   max-height: 200px;
   padding-right: 65px;
-  padding-left: 65px; }
+  padding-left: 65px;
+}
 
 .end-session-dialog-session-list,
 .end-session-dialog-app-list {
-  spacing: 1em; }
+  spacing: 1em;
+}
 
 .end-session-dialog-list-header {
-  font-weight: bold; }
-  .end-session-dialog-list-header:rtl {
-    text-align: right; }
+  font-weight: bold;
+}
+.end-session-dialog-list-header:rtl {
+  text-align: right;
+}
 
 .end-session-dialog-app-list-item,
 .end-session-dialog-session-list-item {
-  spacing: 1em; }
+  spacing: 1em;
+}
 
 .end-session-dialog-app-list-item-name,
 .end-session-dialog-session-list-item-name {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .end-session-dialog-app-list-item-description {
   color: #c8d0e0;
-  font-size: 10pt; }
+  font-size: 10pt;
+}
 
 /* ShellMountOperation Dialogs */
 .shell-mount-operation-icon {
-  icon-size: 48px; }
+  icon-size: 48px;
+}
 
 .mount-dialog {
-  spacing: 24px; }
-  .mount-dialog .message-dialog-title {
-    padding-top: 10px;
-    padding-left: 17px;
-    padding-bottom: 6px;
-    max-width: 34em; }
-  .mount-dialog .message-dialog-title:rtl {
-    padding-left: 0px;
-    padding-right: 17px; }
-  .mount-dialog .message-dialog-body {
-    padding-left: 17px;
-    width: 28em; }
-  .mount-dialog .message-dialog-body:rtl {
-    padding-left: 0px;
-    padding-right: 17px; }
+  spacing: 24px;
+}
+.mount-dialog .message-dialog-title {
+  padding-top: 10px;
+  padding-left: 17px;
+  padding-bottom: 6px;
+  max-width: 34em;
+}
+.mount-dialog .message-dialog-title:rtl {
+  padding-left: 0px;
+  padding-right: 17px;
+}
+.mount-dialog .message-dialog-body {
+  padding-left: 17px;
+  width: 28em;
+}
+.mount-dialog .message-dialog-body:rtl {
+  padding-left: 0px;
+  padding-right: 17px;
+}
 
 .mount-dialog-app-list {
   max-height: 200px;
   padding-top: 24px;
   padding-left: 49px;
-  padding-right: 32px; }
+  padding-right: 32px;
+}
 
 .mount-dialog-app-list:rtl {
   padding-right: 49px;
-  padding-left: 32px; }
+  padding-left: 32px;
+}
 
 .mount-dialog-app-list-item {
-  color: #b7c2d7; }
-  .mount-dialog-app-list-item:hover {
-    color: #d8dee9; }
-  .mount-dialog-app-list-item:ltr {
-    padding-right: 1em; }
-  .mount-dialog-app-list-item:rtl {
-    padding-left: 1em; }
+  color: #b7c2d7;
+}
+.mount-dialog-app-list-item:hover {
+  color: #d8dee9;
+}
+.mount-dialog-app-list-item:ltr {
+  padding-right: 1em;
+}
+.mount-dialog-app-list-item:rtl {
+  padding-left: 1em;
+}
 
 .mount-dialog-app-list-item-icon:ltr {
-  padding-right: 17px; }
-
+  padding-right: 17px;
+}
 .mount-dialog-app-list-item-icon:rtl {
-  padding-left: 17px; }
+  padding-left: 17px;
+}
 
 .mount-dialog-app-list-item-name {
-  font-size: 10pt; }
+  font-size: 10pt;
+}
 
 /* Password or Authentication Dialog */
 .prompt-dialog {
   width: 34em;
   border: none;
-  border-radius: 2px; }
-  .prompt-dialog .message-dialog-main-layout {
-    spacing: 24px;
-    padding: 10px; }
-  .prompt-dialog .message-dialog-content {
-    spacing: 16px; }
-  .prompt-dialog .message-dialog-title {
-    color: #8699bb; }
+  border-radius: 2px;
+}
+.prompt-dialog .message-dialog-main-layout {
+  spacing: 24px;
+  padding: 10px;
+}
+.prompt-dialog .message-dialog-content {
+  spacing: 16px;
+}
+.prompt-dialog .message-dialog-title {
+  color: #8699bb;
+}
 
 .prompt-dialog-description:rtl {
-  text-align: right; }
+  text-align: right;
+}
 
 .prompt-dialog-password-box {
   spacing: 1em;
-  padding-bottom: 1em; }
+  padding-bottom: 1em;
+}
 
 .prompt-dialog-error-label {
   font-size: 10pt;
   color: #b84f59;
-  padding-bottom: 8px; }
+  padding-bottom: 8px;
+}
 
 .prompt-dialog-info-label {
   font-size: 10pt;
-  padding-bottom: 8px; }
+  padding-bottom: 8px;
+}
 
 .hidden {
-  color: rgba(0, 0, 0, 0); }
+  color: rgba(0, 0, 0, 0);
+}
 
 .prompt-dialog-null-label {
   font-size: 10pt;
-  padding-bottom: 8px; }
+  padding-bottom: 8px;
+}
 
 /* Polkit Dialog */
 .polkit-dialog-user-layout {
   padding-left: 10px;
-  spacing: 10px; }
-  .polkit-dialog-user-layout:rtl {
-    padding-left: 0px;
-    padding-right: 10px; }
+  spacing: 10px;
+}
+.polkit-dialog-user-layout:rtl {
+  padding-left: 0px;
+  padding-right: 10px;
+}
 
 .polkit-dialog-user-root-label {
-  color: #c3674a; }
+  color: #c3674a;
+}
 
 .polkit-dialog-user-icon {
   border-radius: 3px;
   background-size: contain;
   width: 48px;
-  height: 48px; }
+  height: 48px;
+}
 
 /* Audio selection dialog */
 .audio-device-selection-dialog {
-  spacing: 30px; }
+  spacing: 30px;
+}
 
 .audio-selection-content {
   spacing: 20px;
-  padding: 24px; }
+  padding: 24px;
+}
 
 .audio-selection-title {
   font-weight: bold;
-  text-align: center; }
+  text-align: center;
+}
 
 .audio-selection-box {
-  spacing: 20px; }
+  spacing: 20px;
+}
 
 .audio-selection-device {
   border: 1px solid #d8dee9;
-  border-radius: 12px; }
-  .audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
-    background-color: #4c566a; }
+  border-radius: 12px;
+}
+.audio-selection-device:active, .audio-selection-device:hover, .audio-selection-device:focus {
+  background-color: #4c566a;
+}
 
 .audio-selection-device-box {
   padding: 20px;
-  spacing: 20px; }
+  spacing: 20px;
+}
 
 .audio-selection-device-icon {
-  icon-size: 64px; }
+  icon-size: 64px;
+}
 
 /* Access Dialog */
 .access-dialog {
-  spacing: 30px; }
+  spacing: 30px;
+}
 
 /* Geolocation Dialog */
 .geolocation-dialog {
-  spacing: 30px; }
+  spacing: 30px;
+}
 
 /* Extension Dialog */
 .extension-dialog .message-dialog-main-layout {
   spacing: 24px;
-  padding: 10px; }
-
+  padding: 10px;
+}
 .extension-dialog .message-dialog-title {
-  color: #8699bb; }
+  color: #8699bb;
+}
 
 /* Inhibit-Shortcuts Dialog */
 .inhibit-shortcuts-dialog {
-  spacing: 30px; }
+  spacing: 30px;
+}
 
 /* Network Agent Dialog */
 .network-dialog-secret-table {
   spacing-rows: 15px;
-  spacing-columns: 1em; }
+  spacing-columns: 1em;
+}
 
 .keyring-dialog-control-table {
   spacing-rows: 15px;
-  spacing-columns: 1em; }
+  spacing-columns: 1em;
+}
 
 /* Popovers/Menus */
 .popup-menu {
   min-width: 15em;
   background-color: transparent;
-  color: #d8dee9; }
-  .popup-menu .popup-sub-menu {
-    background-color: rgba(0, 0, 0, 0.2);
-    box-shadow: 0 2px 4px 2px rgba(0, 0, 0, 0.2); }
-  .popup-menu .popup-menu-content {
-    padding: 16px 0; }
-  .popup-menu .popup-menu-item {
-    spacing: 6px;
-    padding: 6px; }
-    .popup-menu .popup-menu-item:ltr {
-      padding-right: 1.75em;
-      padding-left: 0; }
-    .popup-menu .popup-menu-item:rtl {
-      padding-right: 0;
-      padding-left: 1.75em; }
-    .popup-menu .popup-menu-item:checked {
-      background-color: rgba(76, 86, 106, 0.9);
-      color: #d8dee9;
-      box-shadow: inset 0 1px 0px #2a2f3a;
-      font-weight: bold; }
-      .popup-menu .popup-menu-item:checked:hover {
-        background-color: rgba(76, 86, 106, 0.9);
-        color: #d8dee9; }
-    .popup-menu .popup-menu-item.selected {
-      background-color: rgba(216, 222, 233, 0.1);
-      color: #d8dee9; }
-    .popup-menu .popup-menu-item:active {
-      background-color: #4c566a;
-      color: #d8dee9; }
-    .popup-menu .popup-menu-item:insensitive {
-      color: rgba(216, 222, 233, 0.5); }
-  .popup-menu .popup-inactive-menu-item {
-    color: #d8dee9; }
-    .popup-menu .popup-inactive-menu-item:insensitive {
-      color: rgba(216, 222, 233, 0.5); }
-  .popup-menu.panel-menu {
-    -boxpointer-gap: 4px;
-    margin-bottom: 1.75em; }
+  color: #d8dee9;
+}
+.popup-menu .popup-sub-menu {
+  background-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 4px 2px rgba(0, 0, 0, 0.2);
+}
+.popup-menu .popup-menu-content {
+  padding: 16px 0;
+}
+.popup-menu .popup-menu-item {
+  spacing: 6px;
+  padding: 6px;
+}
+.popup-menu .popup-menu-item:ltr {
+  padding-right: 1.75em;
+  padding-left: 0;
+}
+.popup-menu .popup-menu-item:rtl {
+  padding-right: 0;
+  padding-left: 1.75em;
+}
+.popup-menu .popup-menu-item:checked {
+  background-color: rgba(76, 86, 106, 0.9);
+  color: #d8dee9;
+  box-shadow: inset 0 1px 0px #2a2f3a;
+  font-weight: bold;
+}
+.popup-menu .popup-menu-item:checked:hover {
+  background-color: rgba(76, 86, 106, 0.9);
+  color: #d8dee9;
+}
+.popup-menu .popup-menu-item.selected {
+  background-color: rgba(216, 222, 233, 0.1);
+  color: #d8dee9;
+}
+.popup-menu .popup-menu-item:active {
+  background-color: #4c566a;
+  color: #d8dee9;
+}
+.popup-menu .popup-menu-item:insensitive {
+  color: rgba(216, 222, 233, 0.5);
+}
+.popup-menu .popup-inactive-menu-item {
+  color: #d8dee9;
+}
+.popup-menu .popup-inactive-menu-item:insensitive {
+  color: rgba(216, 222, 233, 0.5);
+}
+.popup-menu.panel-menu {
+  -boxpointer-gap: 4px;
+  margin-bottom: 1.75em;
+}
 
 .popup-menu-ornament {
   text-align: right;
-  width: 1.2em; }
+  width: 1.2em;
+}
 
 .popup-menu-boxpointer,
 .candidate-popup-boxpointer {
@@ -543,7 +671,8 @@ StScrollBar {
   -arrow-border-color: #1f232b;
   -arrow-base: 24px;
   -arrow-rise: 11px;
-  -arrow-box-shadow: 0 1px 3px black; }
+  -arrow-box-shadow: 0 1px 3px black;
+}
 
 .popup-separator-menu-item-separator {
   height: 1px;
@@ -551,15 +680,17 @@ StScrollBar {
   background-color: transparent;
   border-color: transparent;
   border-bottom-width: 1px;
-  border-bottom-style: solid; }
-
+  border-bottom-style: solid;
+}
 .popup-sub-menu .popup-separator-menu-item .popup-separator-menu-item-separator {
   margin: 0 64px 0 32px;
-  background: transparent; }
+  background: transparent;
+}
 
 .background-menu {
   -boxpointer-gap: 4px;
-  -arrow-rise: 0px; }
+  -arrow-rise: 0px;
+}
 
 /* fallback menu
 - odd thing for styling App menu when apparently not running under shell. Light Adwaita styled
@@ -572,110 +703,136 @@ StScrollBar {
   spacing: 1em;
   margin: 32px;
   min-width: 64px;
-  min-height: 64px; }
-  .osd-window .osd-monitor-label {
-    font-size: 3em; }
-  .osd-window .level {
-    height: 0.4em;
-    border-radius: 0.3em;
-    color: #d8dee9;
-    border: 1px solid #1f232b;
-    -barlevel-height: 0.4em;
-    -barlevel-background-color: rgba(3, 4, 5, 0.5);
-    -barlevel-active-background-color: #4c566a;
-    -barlevel-overdrive-color: #bf616a;
-    -barlevel-overdrive-separator-width: 0.2em; }
-  .osd-window .level-bar {
-    background-color: #4c566a;
-    border-radius: 0.3em; }
+  min-height: 64px;
+}
+.osd-window .osd-monitor-label {
+  font-size: 3em;
+}
+.osd-window .level {
+  height: 0.4em;
+  border-radius: 0.3em;
+  color: #d8dee9;
+  border: 1px solid #1f232b;
+  -barlevel-height: 0.4em;
+  -barlevel-background-color: rgba(3, 4, 5, 0.5);
+  -barlevel-active-background-color: #4c566a;
+  -barlevel-overdrive-color: #bf616a;
+  -barlevel-overdrive-separator-width: 0.2em;
+}
+.osd-window .level-bar {
+  background-color: #4c566a;
+  border-radius: 0.3em;
+}
 
 /* Pad OSD */
 .pad-osd-window {
   padding: 32px;
-  background-color: rgba(0, 0, 0, 0.8); }
-  .pad-osd-window .pad-osd-title-box {
-    spacing: 12px; }
-  .pad-osd-window .pad-osd-title-menu-box {
-    spacing: 6px; }
+  background-color: rgba(0, 0, 0, 0.8);
+}
+.pad-osd-window .pad-osd-title-box {
+  spacing: 12px;
+}
+.pad-osd-window .pad-osd-title-menu-box {
+  spacing: 6px;
+}
 
 .combo-box-label {
-  width: 15em; }
+  width: 15em;
+}
 
 /* App Switcher */
 .switcher-popup {
   padding: 8px;
-  spacing: 16px; }
+  spacing: 16px;
+}
 
 .switcher-list-item-container {
-  spacing: 8px; }
+  spacing: 8px;
+}
 
 .switcher-list .item-box {
   padding: 8px;
-  border-radius: 4px; }
+  border-radius: 4px;
+}
 
 .switcher-list .item-box:outlined {
   padding: 6px;
-  border: 2px solid #0a0b0e; }
+  border: 2px solid #0a0b0e;
+}
 
 .switcher-list .item-box:selected {
   background-color: #4c566a;
-  color: #d8dee9; }
+  color: #d8dee9;
+}
 
 .switcher-list .thumbnail-box {
   padding: 2px;
-  spacing: 4px; }
+  spacing: 4px;
+}
 
 .switcher-list .thumbnail {
-  width: 256px; }
+  width: 256px;
+}
 
 .switcher-list .separator {
   width: 1px;
-  background: #1f232b; }
+  background: #1f232b;
+}
 
 .switcher-arrow {
   border-color: rgba(0, 0, 0, 0);
-  color: rgba(216, 222, 233, 0.8); }
-  .switcher-arrow:highlighted {
-    color: #d8dee9; }
+  color: rgba(216, 222, 233, 0.8);
+}
+.switcher-arrow:highlighted {
+  color: #d8dee9;
+}
 
 .input-source-switcher-symbol {
   font-size: 34pt;
   width: 96px;
-  height: 96px; }
+  height: 96px;
+}
 
 /* Window Cycler */
 .cycler-highlight {
-  border: 5px solid #4c566a; }
+  border: 5px solid #4c566a;
+}
 
 /* Workspace Switcher */
 .workspace-switcher-group {
-  padding: 12px; }
+  padding: 12px;
+}
 
 .workspace-switcher {
   background: transparent;
   border: 0px;
   border-radius: 0px;
   padding: 0px;
-  spacing: 8px; }
+  spacing: 8px;
+}
 
 .ws-switcher-active-up, .ws-switcher-active-down {
   height: 50px;
   background-color: #4c566a;
   color: #d8dee9;
   background-size: 32px;
-  border-radius: 8px; }
+  border-radius: 8px;
+}
 
 .ws-switcher-active-up {
-  background-image: url("assets/ws-switch-arrow-up.png"); }
+  background-image: url("assets/ws-switch-arrow-up.png");
+}
 
 .ws-switcher-active-down {
-  background-image: url("assets/ws-switch-arrow-down.png"); }
+  background-image: url("assets/ws-switch-arrow-down.png");
+}
 
 .ws-switcher-box {
   height: 50px;
   border: 1px solid rgba(216, 222, 233, 0.1);
   background: rgba(25, 28, 34, 0.95);
-  border-radius: 8px; }
+  border-radius: 8px;
+}
 
 .osd-window,
 .resize-popup,
@@ -685,21 +842,26 @@ StScrollBar {
   border: 1px solid #1f232b;
   box-shadow: 0px 0px 5px #1f232b;
   border-radius: 5px;
-  padding: 12px; }
+  padding: 12px;
+}
 
 /* Tiled window previews */
 .tile-preview {
   background-color: rgba(76, 86, 106, 0.5);
-  border: 1px solid #4c566a; }
+  border: 1px solid #4c566a;
+}
 
 .tile-preview-left.on-primary {
-  border-radius: 2px 2px 0 0; }
+  border-radius: 2px 2px 0 0;
+}
 
 .tile-preview-right.on-primary {
-  border-radius: 0 2px 0 0; }
+  border-radius: 0 2px 0 0;
+}
 
 .tile-preview-left.tile-preview-right.on-primary {
-  border-radius: 2px 2px 0 0; }
+  border-radius: 2px 2px 0 0;
+}
 
 /* TOP BAR */
 #panel {
@@ -709,107 +871,130 @@ StScrollBar {
   transition-duration: 500ms;
   font-weight: bold;
   height: 1.86em;
-  padding: 0px 0px; }
-  #panel.unlock-screen, #panel.login-screen, #panel.lock-screen {
-    background-color: transparent; }
-  #panel #panelLeft, #panel #panelCenter {
-    spacing: 4px; }
-  #panel .panel-corner {
-    -panel-corner-radius: 0px;
-    -panel-corner-background-color: rgba(0, 0, 0, 0.2);
-    -panel-corner-border-width: 2px;
-    -panel-corner-border-color: transparent; }
-    #panel .panel-corner:active, #panel .panel-corner:overview, #panel .panel-corner:focus {
-      -panel-corner-border-color: #576279; }
-    #panel .panel-corner.lock-screen, #panel .panel-corner.login-screen, #panel .panel-corner.unlock-screen {
-      -panel-corner-radius: 0;
-      -panel-corner-background-color: transparent;
-      -panel-corner-border-color: transparent; }
-  #panel .panel-button {
-    -natural-hpadding: 12px;
-    -minimum-hpadding: 6px;
-    font-weight: bold;
-    color: #d8dee9;
-    transition-duration: 100ms; }
-    #panel .panel-button .app-menu-icon {
-      -st-icon-style: symbolic;
-      margin-left: 4px;
-      margin-right: 4px; }
-    #panel .panel-button:hover {
-      background: #323946;
-      color: #f9fafb; }
-    #panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
-      background: #4c566a;
-      box-shadow: inset 0 -2px 0px #576279;
-      color: #fff; }
-    #panel .panel-button .system-status-icon {
-      icon-size: 1.09em;
-      padding: 0 5px; }
-    .unlock-screen #panel .panel-button,
-    .login-screen #panel .panel-button,
-    .lock-screen #panel .panel-button {
-      color: #f9fafb; }
-      .unlock-screen #panel .panel-button:focus, .unlock-screen #panel .panel-button:hover, .unlock-screen #panel .panel-button:active,
-      .login-screen #panel .panel-button:focus,
-      .login-screen #panel .panel-button:hover,
-      .login-screen #panel .panel-button:active,
-      .lock-screen #panel .panel-button:focus,
-      .lock-screen #panel .panel-button:hover,
-      .lock-screen #panel .panel-button:active {
-        color: #f9fafb; }
-    #panel .panel-button.clock-display:active, #panel .panel-button.clock-display:overview, #panel .panel-button.clock-display:focus, #panel .panel-button.clock-display:checked {
-      box-shadow: none; }
-      #panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:overview .clock, #panel .panel-button.clock-display:focus .clock, #panel .panel-button.clock-display:checked .clock {
-        box-shadow: none; }
-  #panel .panel-status-indicators-box,
-  #panel .panel-status-menu-box {
-    spacing: 2px; }
-  #panel .power-status.panel-status-indicators-box {
-    spacing: 0; }
-  #panel .screencast-indicator {
-    color: #c3674a; }
-  #panel.solid {
-    background-color: #1d2128;
-    /* transition from transparent to solid */
-    transition-duration: 300ms; }
-    #panel.solid .panel-corner {
-      -panel-corner-background-color: black; }
-    #panel.solid .system-status-icon,
-    #panel.solid .app-menu-icon > StIcon,
-    #panel.solid .popup-menu-arrow {
-      icon-shadow: none; }
+  padding: 0px 0px;
+}
+#panel.unlock-screen, #panel.login-screen, #panel.lock-screen {
+  background-color: transparent;
+}
+#panel #panelLeft, #panel #panelCenter {
+  spacing: 4px;
+}
+#panel .panel-corner {
+  -panel-corner-radius: 0px;
+  -panel-corner-background-color: rgba(0, 0, 0, 0.2);
+  -panel-corner-border-width: 2px;
+  -panel-corner-border-color: transparent;
+}
+#panel .panel-corner:active, #panel .panel-corner:overview, #panel .panel-corner:focus {
+  -panel-corner-border-color: #576279;
+}
+#panel .panel-corner.lock-screen, #panel .panel-corner.login-screen, #panel .panel-corner.unlock-screen {
+  -panel-corner-radius: 0;
+  -panel-corner-background-color: transparent;
+  -panel-corner-border-color: transparent;
+}
+#panel .panel-button {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: #d8dee9;
+  transition-duration: 100ms;
+}
+#panel .panel-button .app-menu-icon {
+  -st-icon-style: symbolic;
+  margin-left: 4px;
+  margin-right: 4px;
+}
+#panel .panel-button:hover {
+  background: #323946;
+  color: #f9fafb;
+}
+#panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
+  background: #4c566a;
+  box-shadow: inset 0 -2px 0px #576279;
+  color: #fff;
+}
+#panel .panel-button .system-status-icon {
+  icon-size: 1.09em;
+  padding: 0 5px;
+}
+.unlock-screen #panel .panel-button, .login-screen #panel .panel-button, .lock-screen #panel .panel-button {
+  color: #f9fafb;
+}
+.unlock-screen #panel .panel-button:focus, .unlock-screen #panel .panel-button:hover, .unlock-screen #panel .panel-button:active, .login-screen #panel .panel-button:focus, .login-screen #panel .panel-button:hover, .login-screen #panel .panel-button:active, .lock-screen #panel .panel-button:focus, .lock-screen #panel .panel-button:hover, .lock-screen #panel .panel-button:active {
+  color: #f9fafb;
+}
+#panel .panel-button.clock-display:active, #panel .panel-button.clock-display:overview, #panel .panel-button.clock-display:focus, #panel .panel-button.clock-display:checked {
+  box-shadow: none;
+}
+#panel .panel-button.clock-display:active .clock, #panel .panel-button.clock-display:overview .clock, #panel .panel-button.clock-display:focus .clock, #panel .panel-button.clock-display:checked .clock {
+  box-shadow: none;
+}
+#panel .panel-status-indicators-box,
+#panel .panel-status-menu-box {
+  spacing: 2px;
+}
+#panel .power-status.panel-status-indicators-box {
+  spacing: 0;
+}
+#panel .screencast-indicator {
+  color: #c3674a;
+}
+#panel.solid {
+  background-color: #1d2128;
+  /* transition from transparent to solid */
+  transition-duration: 300ms;
+}
+#panel.solid .panel-corner {
+  -panel-corner-background-color: black;
+}
+#panel.solid .system-status-icon,
+#panel.solid .app-menu-icon > StIcon,
+#panel.solid .popup-menu-arrow {
+  icon-shadow: none;
+}
 
 #calendarArea {
-  padding: 0.75em 1.0em; }
+  padding: 0.75em 1em;
+}
 
 .calendar {
-  margin-bottom: 1em; }
+  margin-bottom: 1em;
+}
 
 .calendar, .world-clocks-button, .weather-button, .events-button {
   background: transparent;
-  border: none; }
+  border: none;
+}
 
 .calendar,
 .datemenu-today-button,
 .datemenu-displays-box,
 .message-list-sections {
-  margin: 0 1.5em; }
+  margin: 0 1.5em;
+}
 
 .datemenu-calendar-column {
-  spacing: 0.5em; }
+  spacing: 0.5em;
+}
 
 .datemenu-displays-section {
-  padding-bottom: 3em; }
+  padding-bottom: 3em;
+}
 
 .datemenu-displays-box {
-  spacing: 1em; }
+  spacing: 1em;
+}
 
 .datemenu-calendar-column {
-  border: 0 solid transparent; }
-  .datemenu-calendar-column:ltr {
-    border-left-width: 1px; }
-  .datemenu-calendar-column:rtl {
-    border-right-width: 1px; }
+  border: 0 solid transparent;
+}
+.datemenu-calendar-column:ltr {
+  border-left-width: 1px;
+}
+.datemenu-calendar-column:rtl {
+  border-right-width: 1px;
+}
 
 .datemenu-today-button,
 .world-clocks-button,
@@ -819,13 +1004,16 @@ StScrollBar {
 .events-button {
   border-radius: 4px;
   color: #d8dee9;
-  padding: .4em; }
+  padding: 0.4em;
+}
 
 .message-list-section-list:ltr {
-  padding-left: .4em; }
+  padding-left: 0.4em;
+}
 
 .message-list-section-list:rtl {
-  padding-right: .4em; }
+  padding-right: 0.4em;
+}
 
 .datemenu-today-button:hover, .datemenu-today-button:focus,
 .world-clocks-button:hover,
@@ -838,8 +1026,8 @@ StScrollBar {
 .message-list-section-title:focus,
 .events-button:hover,
 .events-button:focus {
-  background-color: #39404f; }
-
+  background-color: #39404f;
+}
 .datemenu-today-button:active,
 .world-clocks-button:active,
 .weather-button:active,
@@ -847,10 +1035,12 @@ StScrollBar {
 .message-list-section-title:active,
 .events-button:active {
   color: #e8ecf2;
-  background-color: #4c566a; }
+  background-color: #4c566a;
+}
 
 .datemenu-today-button .date-label {
-  font-size: 1.5em; }
+  font-size: 1.5em;
+}
 
 .world-clocks-header,
 .weather-header,
@@ -858,45 +1048,57 @@ StScrollBar {
 .message-list-section-title,
 .events-title {
   color: #58709d;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .events-button .event-time {
-  color: #cbd3e2; }
+  color: #cbd3e2;
+}
 
 .world-clocks-grid {
-  spacing-rows: 0.4em; }
+  spacing-rows: 0.4em;
+}
 
 .weather-box {
-  spacing: 0.4em; }
+  spacing: 0.4em;
+}
 
 .calendar-month-label {
   color: #c8d0e0;
   font-weight: bold;
-  padding: 8px 0; }
-
+  padding: 8px 0;
+}
 .pager-button {
   color: white;
   background-color: transparent;
   width: 32px;
-  border-radius: 4px; }
-  .pager-button:hover, .pager-button:focus {
-    background-color: rgba(216, 222, 233, 0.05); }
-  .pager-button:active {
-    background-color: rgba(46, 52, 64, 0.05); }
+  border-radius: 4px;
+}
+.pager-button:hover, .pager-button:focus {
+  background-color: rgba(216, 222, 233, 0.05);
+}
+.pager-button:active {
+  background-color: rgba(46, 52, 64, 0.05);
+}
 
 .calendar-change-month-back {
-  background-image: url("assets/calendar-arrow-left.svg"); }
-  .calendar-change-month-back:rtl {
-    background-image: url("assets/calendar-arrow-right.svg"); }
+  background-image: url("assets/calendar-arrow-left.svg");
+}
+.calendar-change-month-back:rtl {
+  background-image: url("assets/calendar-arrow-right.svg");
+}
 
 .calendar-change-month-forward {
-  background-image: url("assets/calendar-arrow-right.svg"); }
-  .calendar-change-month-forward:rtl {
-    background-image: url("assets/calendar-arrow-left.svg"); }
+  background-image: url("assets/calendar-arrow-right.svg");
+}
+.calendar-change-month-forward:rtl {
+  background-image: url("assets/calendar-arrow-left.svg");
+}
 
 .calendar-change-month-back StIcon,
 .calendar-change-month-forward StIcon {
-  color: #c1cbdc; }
+  color: #c1cbdc;
+}
 
 .calendar-day-base {
   font-size: 80%;
@@ -906,42 +1108,53 @@ StScrollBar {
   padding: 0.1em;
   margin: 2px;
   border-radius: 1.4em;
-  color: #d8dee9; }
-  .calendar-day-base:hover, .calendar-day-base:focus {
-    background-color: #39404f; }
-  .calendar-day-base:active, .calendar-day-base:selected {
-    color: #e8ecf2;
-    background-color: #4c566a;
-    border-color: transparent; }
-  .calendar-day-base.calendar-day-heading {
-    color: #58709d;
-    margin-top: 1em;
-    font-size: 70%; }
+  color: #d8dee9;
+}
+.calendar-day-base:hover, .calendar-day-base:focus {
+  background-color: #39404f;
+}
+.calendar-day-base:active, .calendar-day-base:selected {
+  color: #e8ecf2;
+  background-color: #4c566a;
+  border-color: transparent;
+}
+.calendar-day-base.calendar-day-heading {
+  color: #58709d;
+  margin-top: 1em;
+  font-size: 70%;
+}
 
 .calendar-day {
-  border-width: 0; }
+  border-width: 0;
+}
 
 .calendar-day-top {
-  border-top-width: 1px; }
+  border-top-width: 1px;
+}
 
 .calendar-day-left {
-  border-left-width: 1px; }
+  border-left-width: 1px;
+}
 
 .calendar-nonwork-day {
-  color: #838995; }
+  color: #838995;
+}
 
 .calendar-today {
   font-weight: bold;
-  border: 1px solid rgba(31, 35, 43, 0.5); }
+  border: 1px solid rgba(31, 35, 43, 0.5);
+}
 
 .calendar-day-with-events {
   color: #f9fafb;
   font-weight: bold;
-  background-image: url("assets/calendar-today.svg"); }
+  background-image: url("assets/calendar-today.svg");
+}
 
 .calendar-other-month-day {
   color: #838995;
-  opacity: 0.5; }
+  opacity: 0.5;
+}
 
 .calendar-week-number {
   font-size: 70%;
@@ -952,134 +1165,166 @@ StScrollBar {
   padding: 0.5em 0 0;
   margin: 6px;
   background-color: rgba(216, 222, 233, 0.3);
-  color: #2e3440; }
+  color: #2e3440;
+}
 
 /* Message list */
 .message-list {
-  width: 31.5em; }
-  .message-list .message-title, .message-list .message-content, .message-list .message-body {
-    color: #c8d0e0; }
+  width: 31.5em;
+}
+.message-list .message-title, .message-list .message-content, .message-list .message-body {
+  color: #c8d0e0;
+}
 
 .message-list-clear-button.button {
   border: 1px solid #1f232b;
   box-shadow: none;
-  margin: 1.5em 1.5em 0; }
-  .message-list-clear-button.button:hover, .message-list-clear-button.button:focus {
-    background-color: #39404f; }
+  margin: 1.5em 1.5em 0;
+}
+.message-list-clear-button.button:hover, .message-list-clear-button.button:focus {
+  background-color: #39404f;
+}
 
 .message-list-sections {
-  spacing: 1em; }
+  spacing: 1em;
+}
 
 .message-list-section,
 .message-list-section-list {
-  spacing: 0.4em; }
+  spacing: 0.4em;
+}
 
 .message-list-section-close > StIcon {
   icon-size: 16px;
   border-radius: 16px;
   padding: 8px;
   color: #d8dee9;
-  background-color: transparent; }
-
-.message-list-section-close:hover > StIcon,
-.message-list-section-close:focus > StIcon .message-list-section-close:active > StIcon {
+  background-color: transparent;
+}
+.message-list-section-close:hover > StIcon, .message-list-section-close:focus > StIcon .message-list-section-close:active > StIcon {
   color: #bf616a;
-  background: transparent; }
+  background: transparent;
+}
 
 .message {
   border: 1px solid #1f232b;
   border-radius: 3px;
   background: #2d323e;
-  box-shadow: none; }
-  .message:hover, .message:focus {
-    background-color: #323946;
-    box-shadow: 3px 0px 0px 0px #4c566a inset; }
+  box-shadow: none;
+}
+.message:hover, .message:focus {
+  background-color: #323946;
+  box-shadow: 3px 0px 0px 0px #4c566a inset;
+}
 
 .message-icon-bin {
-  padding: 10px 3px 10px 10px; }
-  .message-icon-bin:rtl {
-    padding: 10px 10px 10px 3px; }
+  padding: 10px 3px 10px 10px;
+}
+.message-icon-bin:rtl {
+  padding: 10px 10px 10px 3px;
+}
 
 .message-icon-bin > StIcon {
   icon-size: 16px;
-  -st-icon-style: symbolic; }
+  -st-icon-style: symbolic;
+}
 
 .message-secondary-bin {
-  padding: 0 12px; }
+  padding: 0 12px;
+}
 
 .message-secondary-bin > .event-time {
   color: #a7b5cd;
   font-size: 0.7em;
   /* HACK: the label should be baseline-aligned with a 1em label,
-                     fake this with some bottom padding */
-  padding-bottom: 0.13em; }
+           fake this with some bottom padding */
+  padding-bottom: 0.13em;
+}
 
 .message-secondary-bin > StIcon {
-  icon-size: 16px; }
+  icon-size: 16px;
+}
 
 .message-content {
-  padding: 10px; }
-  .message-content *:hover > StIcon,
-  .message-content *:focus > StIcon {
-    color: #bf616a; }
+  padding: 10px;
+}
+.message-content *:hover > StIcon,
+.message-content *:focus > StIcon {
+  color: #bf616a;
+}
 
 .message-media-control {
   padding: 12px;
-  color: #97a7c4; }
-  .message-media-control:last-child:ltr {
-    padding-right: 18px; }
-  .message-media-control:last-child:rtl {
-    padding-left: 18px; }
-  .message-media-control:hover {
-    color: #d8dee9; }
-  .message-media-control:insensitive {
-    color: #58709d; }
+  color: #97a7c4;
+}
+.message-media-control:last-child:ltr {
+  padding-right: 18px;
+}
+.message-media-control:last-child:rtl {
+  padding-left: 18px;
+}
+.message-media-control:hover {
+  color: #d8dee9;
+}
+.message-media-control:insensitive {
+  color: #58709d;
+}
 
 .media-message-cover-icon {
-  icon-size: 48px !important; }
-  .media-message-cover-icon.fallback {
-    color: #434c5e;
-    background-color: #2e3440;
-    border: 2px solid #2e3440;
-    border-radius: 2px;
-    icon-size: 16px;
-    padding: 8px; }
+  icon-size: 48px !important;
+}
+.media-message-cover-icon.fallback {
+  color: #434c5e;
+  background-color: #2e3440;
+  border: 2px solid #2e3440;
+  border-radius: 2px;
+  icon-size: 16px;
+  padding: 8px;
+}
 
 /* Weather */
 .weather-button .weather-header {
   color: #b7c2d7;
-  font-weight: bold; }
-  .weather-button .weather-header.location {
-    font-weight: normal; }
-
+  font-weight: bold;
+}
+.weather-button .weather-header.location {
+  font-weight: normal;
+}
 .weather-button .weather-forecast-time {
   color: #b7c2d7;
   font-feature-settings: "tnum";
   font-weight: normal;
   padding-top: 0.2em;
-  padding-bottom: 0.4em; }
-
+  padding-bottom: 0.4em;
+}
 .weather-button .weather-forecast-temp {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .system-switch-user-submenu-icon.user-icon {
   icon-size: 20px;
-  padding: 0 2px; }
+  padding: 0 2px;
+}
 
 .system-switch-user-submenu-icon.default-icon {
   icon-size: 16px;
-  padding: 0 4px; }
+  padding: 0 4px;
+}
 
 #appMenu {
   spinner-image: url("assets/process-working.svg");
-  spacing: 4px; }
-  #appMenu .label-shadow {
-    color: transparent; }
+  spacing: 4px;
+}
+#appMenu .label-shadow {
+  color: transparent;
+}
 
 .aggregate-menu {
-  min-width: 21em; }
-  .aggregate-menu .popup-menu-icon {
-    padding: 0 4px; }
+  min-width: 21em;
+}
+.aggregate-menu .popup-menu-icon {
+  padding: 0 4px;
+}
 
 .system-menu-action {
   color: #d8dee9;
@@ -1087,32 +1332,40 @@ StScrollBar {
   /* wish we could do 50% */
   border: 1px solid #1f232b;
   background: #282d37;
-  padding: 13px; }
-  .system-menu-action:hover, .system-menu-action:focus {
-    border: 1px solid #4c566a;
-    color: #4c566a;
-    background: transparent; }
-  .system-menu-action:active {
-    background-color: #373e4c;
-    color: #d8dee9; }
-  .system-menu-action > StIcon {
-    icon-size: 16px; }
+  padding: 13px;
+}
+.system-menu-action:hover, .system-menu-action:focus {
+  border: 1px solid #4c566a;
+  color: #4c566a;
+  background: transparent;
+}
+.system-menu-action:active {
+  background-color: #373e4c;
+  color: #d8dee9;
+}
+.system-menu-action > StIcon {
+  icon-size: 16px;
+}
 
 .ripple-box {
   width: 52px;
   height: 52px;
   background-image: url("assets/corner-ripple-ltr.png");
-  background-size: contain; }
+  background-size: contain;
+}
 
 .ripple-box:rtl {
-  background-image: url("assets/corner-ripple-rtl.png"); }
+  background-image: url("assets/corner-ripple-rtl.png");
+}
 
 .popup-menu-arrow {
   width: 16px;
-  height: 16px; }
+  height: 16px;
+}
 
 .popup-menu-icon {
-  icon-size: 1.09em; }
+  icon-size: 1.09em;
+}
 
 .window-close {
   background-color: transparent;
@@ -1122,93 +1375,121 @@ StScrollBar {
   box-shadow: none;
   color: transparent;
   height: 32px;
-  width: 32px; }
+  width: 32px;
+}
 
 .window-close {
-  -shell-close-overlap: 16px; }
-  .window-close:rtl {
-    -st-background-image-shadow: 2px 2px 6px rgba(0, 0, 0, 0.5); }
+  -shell-close-overlap: 16px;
+}
+.window-close:rtl {
+  -st-background-image-shadow: 2px 2px 6px rgba(0, 0, 0, 0.5);
+}
 
 /* NETWORK DIALOGS */
 .nm-dialog {
   max-height: 34em;
   min-height: 31em;
-  min-width: 32em; }
+  min-width: 32em;
+}
 
 .nm-dialog-content {
   spacing: 20px;
-  padding: 24px; }
+  padding: 24px;
+}
 
 .nm-dialog-header-hbox {
-  spacing: 10px; }
+  spacing: 10px;
+}
 
 .nm-dialog-airplane-box {
-  spacing: 12px; }
+  spacing: 12px;
+}
 
 .nm-dialog-airplane-headline {
   font-weight: bold;
-  text-align: center; }
+  text-align: center;
+}
 
 .nm-dialog-airplane-text {
-  color: #d8dee9; }
+  color: #d8dee9;
+}
 
 .nm-dialog-header-icon {
-  icon-size: 32px; }
+  icon-size: 32px;
+}
 
 .nm-dialog-scroll-view {
   border: 2px solid #1f232b;
-  background: transparent; }
+  background: transparent;
+}
 
 .nm-dialog-header {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .nm-dialog-item {
   font-size: 110%;
   border-bottom: 1px solid #1f232b;
   padding: 12px;
-  spacing: 20px; }
+  spacing: 20px;
+}
 
 .nm-dialog-item:selected {
   background-color: #4c566a;
-  color: #d8dee9; }
+  color: #d8dee9;
+}
 
 .nm-dialog-icons {
-  spacing: .5em; }
+  spacing: 0.5em;
+}
 
 .nm-dialog-icon {
-  icon-size: 16px; }
+  icon-size: 16px;
+}
 
 .no-networks-label {
-  color: #999999; }
+  color: #999999;
+}
 
 .no-networks-box {
-  spacing: 12px; }
+  spacing: 12px;
+}
 
 /* OVERVIEW */
 #overview {
-  spacing: 24px; }
+  spacing: 24px;
+}
+
+#overview.cosmic-solid-bg {
+  background-color: #1d2128 !important;
+}
 
 .overview-controls {
-  padding-bottom: 32px; }
+  padding-bottom: 32px;
+}
 
 .window-picker {
   -horizontal-spacing: 16px;
   -vertical-spacing: 16px;
-  padding: 0 16px 16px; }
-  .window-picker.external-monitor {
-    padding: 16px; }
+  padding: 0 16px 16px;
+}
+.window-picker.external-monitor {
+  padding: 16px;
+}
 
 .window-clone-border {
   border: 4px solid rgba(76, 86, 106, 0.3);
   border-radius: 0px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3); }
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
 
 .window-caption {
   spacing: 20px;
   color: #d8dee9;
   background-color: rgba(46, 52, 64, 0.65);
   border-radius: 2px;
-  padding: 4px 8px; }
+  padding: 4px 8px;
+}
 
 .search-entry {
   width: 320px;
@@ -1217,66 +1498,83 @@ StScrollBar {
   border: none;
   color: #d8dee9;
   background-color: rgba(46, 52, 64, 0.6);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
-  .search-entry:focus {
-    border-width: 0;
-    color: #d8dee9;
-    background-color: rgba(46, 52, 64, 0.8);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15); }
-  .search-entry .search-entry-icon {
-    icon-size: 1em;
-    padding: 0 4px;
-    color: rgba(216, 222, 233, 0.7); }
-  .search-entry:hover, .search-entry:focus {
-    background-color: rgba(46, 52, 64, 0.8); }
-    .search-entry:hover .search-entry-icon, .search-entry:focus .search-entry-icon {
-      color: #d8dee9; }
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.search-entry:focus {
+  border-width: 0;
+  color: #d8dee9;
+  background-color: rgba(46, 52, 64, 0.8);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+.search-entry .search-entry-icon {
+  icon-size: 1em;
+  padding: 0 4px;
+  color: rgba(216, 222, 233, 0.7);
+}
+.search-entry:hover, .search-entry:focus {
+  background-color: rgba(46, 52, 64, 0.8);
+}
+.search-entry:hover .search-entry-icon, .search-entry:focus .search-entry-icon {
+  color: #d8dee9;
+}
 
 #searchResultsBin {
-  max-width: 1000px; }
+  max-width: 1000px;
+}
 
 #searchResultsContent {
   padding-left: 20px;
   padding-right: 20px;
-  spacing: 16px; }
+  spacing: 16px;
+}
 
 .search-section {
-  spacing: 16px; }
+  spacing: 16px;
+}
 
 .search-section-content {
   background-color: transparent;
   border-radius: 0;
   border: none;
   box-shadow: none;
-  spacing: 32px; }
+  spacing: 32px;
+}
 
 .list-search-results {
-  spacing: 3px; }
+  spacing: 3px;
+}
 
 .search-section-separator {
   height: 2px;
-  background-color: rgba(255, 255, 255, 0.2); }
+  background-color: rgba(255, 255, 255, 0.2);
+}
 
 .list-search-result-content {
-  spacing: 30px; }
+  spacing: 30px;
+}
 
 .list-search-result-title {
   color: #e8ecf2;
-  spacing: 12px; }
+  spacing: 12px;
+}
 
 .list-search-result-description {
-  color: rgba(255, 255, 255, 0.5); }
+  color: rgba(255, 255, 255, 0.5);
+}
 
 .list-search-provider-details {
   width: 150px;
   color: #e8ecf2;
-  margin-top: 0.24em; }
+  margin-top: 0.24em;
+}
 
 .list-search-provider-content {
-  spacing: 20px; }
+  spacing: 20px;
+}
 
 .search-provider-icon {
-  padding: 15px; }
+  padding: 15px;
+}
 
 /* DASHBOARD */
 #dash {
@@ -1286,19 +1584,24 @@ StScrollBar {
   padding: 6px 0;
   border: 1px solid #1f232b;
   border-left: 0px;
-  border-radius: 0px 5px 5px 0px; }
-  #dash:rtl {
-    border-radius: 9px 0 0 9px; }
-  #dash .placeholder {
-    background-image: url("assets/dash-placeholder.svg");
-    background-size: contain;
-    height: 24px; }
-  #dash .empty-dash-drop-target {
-    width: 24px;
-    height: 24px; }
+  border-radius: 0px 5px 5px 0px;
+}
+#dash:rtl {
+  border-radius: 9px 0 0 9px;
+}
+#dash .placeholder {
+  background-image: url("assets/dash-placeholder.svg");
+  background-size: contain;
+  height: 24px;
+}
+#dash .empty-dash-drop-target {
+  width: 24px;
+  height: 24px;
+}
 
 .dash-item-container > StWidget {
-  padding: 4px 8px; }
+  padding: 4px 8px;
+}
 
 .dash-label {
   border-radius: 7px;
@@ -1306,83 +1609,93 @@ StScrollBar {
   color: #d8dee9;
   background-color: #1d2128;
   text-align: center;
-  -x-offset: 8px; }
+  -x-offset: 8px;
+}
 
 /* App Vault/Grid */
 .icon-grid {
   spacing: 30px;
   -shell-grid-horizontal-item-size: 136px;
-  -shell-grid-vertical-item-size: 136px; }
-  .icon-grid .overview-icon {
-    icon-size: 96px; }
+  -shell-grid-vertical-item-size: 136px;
+}
+.icon-grid .overview-icon {
+  icon-size: 96px;
+}
 
 .system-action-icon {
   background-color: black;
   color: white;
   border-radius: 99px;
-  icon-size: 48px; }
+  icon-size: 48px;
+}
 
 .app-view-controls {
-  padding-bottom: 32px; }
+  padding-bottom: 32px;
+}
 
 .app-view-control {
-  padding: 4px 32px; }
-  .app-view-control:checked {
-    color: #4c566a;
-    background-color: rgba(46, 52, 64, 0.95);
-    border: 1px solid #1f232b;
-    text-shadow: none;
-    icon-shadow: none; }
-  .app-view-control:first-child {
-    border-right-width: 0;
-    border-radius: 3px 0 0 3px; }
-  .app-view-control:last-child {
-    border-radius: 0 3px 3px 0; }
+  padding: 4px 32px;
+}
+.app-view-control:checked {
+  color: #4c566a;
+  background-color: rgba(46, 52, 64, 0.95);
+  border: 1px solid #1f232b;
+  text-shadow: none;
+  icon-shadow: none;
+}
+.app-view-control:first-child {
+  border-right-width: 0;
+  border-radius: 3px 0 0 3px;
+}
+.app-view-control:last-child {
+  border-radius: 0 3px 3px 0;
+}
 
 .search-provider-icon:active, .search-provider-icon:checked,
 .list-search-result:active,
 .list-search-result:checked {
-  background-color: rgba(25, 28, 34, 0.85); }
-
+  background-color: rgba(25, 28, 34, 0.85);
+}
 .search-provider-icon:focus, .search-provider-icon:selected, .search-provider-icon:hover,
 .list-search-result:focus,
 .list-search-result:selected,
 .list-search-result:hover {
   background-color: rgba(46, 52, 64, 0.3);
-  transition-duration: 200ms; }
+  transition-duration: 200ms;
+}
 
 .app-well-app,
 .app-well-app.app-folder,
 .show-apps,
 .grid-search-result {
-  border: none; }
-  .app-well-app:active .overview-icon,
-  .app-well-app:checked .overview-icon,
-  .app-well-app.app-folder:active .overview-icon,
-  .app-well-app.app-folder:checked .overview-icon,
-  .show-apps:active .overview-icon,
-  .show-apps:checked .overview-icon,
-  .grid-search-result:active .overview-icon,
-  .grid-search-result:checked .overview-icon {
-    background-color: rgba(31, 35, 43, 0.85);
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.15);
-    color: #d8dee9; }
-  .app-well-app:hover .overview-icon,
-  .app-well-app:focus .overview-icon,
-  .app-well-app:selected .overview-icon,
-  .app-well-app.app-folder:hover .overview-icon,
-  .app-well-app.app-folder:focus .overview-icon,
-  .app-well-app.app-folder:selected .overview-icon,
-  .show-apps:hover .overview-icon,
-  .show-apps:focus .overview-icon,
-  .show-apps:selected .overview-icon,
-  .grid-search-result:hover .overview-icon,
-  .grid-search-result:focus .overview-icon,
-  .grid-search-result:selected .overview-icon {
-    background-color: rgba(46, 52, 64, 0.5);
-    transition-duration: 0ms;
-    border-image: none;
-    background-image: none; }
+  border: none;
+}
+.app-well-app:active .overview-icon, .app-well-app:checked .overview-icon,
+.app-well-app.app-folder:active .overview-icon,
+.app-well-app.app-folder:checked .overview-icon,
+.show-apps:active .overview-icon,
+.show-apps:checked .overview-icon,
+.grid-search-result:active .overview-icon,
+.grid-search-result:checked .overview-icon {
+  background-color: rgba(31, 35, 43, 0.85);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.15);
+  color: #d8dee9;
+}
+.app-well-app:hover .overview-icon, .app-well-app:focus .overview-icon, .app-well-app:selected .overview-icon,
+.app-well-app.app-folder:hover .overview-icon,
+.app-well-app.app-folder:focus .overview-icon,
+.app-well-app.app-folder:selected .overview-icon,
+.show-apps:hover .overview-icon,
+.show-apps:focus .overview-icon,
+.show-apps:selected .overview-icon,
+.grid-search-result:hover .overview-icon,
+.grid-search-result:focus .overview-icon,
+.grid-search-result:selected .overview-icon {
+  background-color: rgba(46, 52, 64, 0.5);
+  transition-duration: 0ms;
+  border-image: none;
+  background-image: none;
+}
 
 .app-well-app-running-dot {
   width: 4px;
@@ -1390,7 +1703,8 @@ StScrollBar {
   background-color: #4c566a;
   border-radius: 10px !important;
   box-shadow: 0px 0px 5px 4px rgba(76, 86, 106, 0.8);
-  margin-bottom: 0px; }
+  margin-bottom: 0px;
+}
 
 .search-provider-icon,
 .list-search-result, .app-well-app .overview-icon,
@@ -1403,89 +1717,109 @@ StScrollBar {
   border: none;
   transition-duration: 100ms;
   text-align: center;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
 
 .app-well-app.app-folder > .overview-icon {
-  background-color: rgba(46, 52, 64, 0.35); }
+  background-color: rgba(46, 52, 64, 0.35);
+}
 
 .show-apps .show-apps-icon {
-  color: #d8dee9; }
+  color: #d8dee9;
+}
 
 .show-apps:checked .show-apps-icon,
 .show-apps:focus .show-apps-icon {
   color: #d8dee9;
-  transition-duration: 100ms; }
+  transition-duration: 100ms;
+}
 
 .app-folder-popup {
   -arrow-border-radius: 8px;
   -arrow-background-color: rgba(46, 52, 64, 0.5);
   -arrow-base: 24px;
-  -arrow-rise: 11px; }
+  -arrow-rise: 11px;
+}
 
 .app-folder-popup-bin {
   padding: 5px;
-  background: rgba(46, 52, 64, 0.5); }
+  background: rgba(46, 52, 64, 0.5);
+}
 
 .app-folder-icon {
   padding: 5px;
   spacing-rows: 5px;
-  spacing-columns: 5px; }
+  spacing-columns: 5px;
+}
 
 .page-indicator {
-  padding: 15px 20px; }
-  .page-indicator .page-indicator-icon {
-    width: 12px;
-    height: 12px;
-    border-radius: 12px;
-    background-image: none;
-    background-color: rgba(255, 255, 255, 0.3); }
-  .page-indicator:hover .page-indicator-icon {
-    background-image: none;
-    background-color: rgba(255, 255, 255, 0.5); }
-  .page-indicator:active .page-indicator-icon {
-    background-image: none;
-    background-color: rgba(255, 255, 255, 0.7); }
-  .page-indicator:checked .page-indicator-icon {
-    background-image: none;
-    background-color: #FFFFFF;
-    transition-duration: 0s; }
+  padding: 15px 20px;
+}
+.page-indicator .page-indicator-icon {
+  width: 12px;
+  height: 12px;
+  border-radius: 12px;
+  background-image: none;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+.page-indicator:hover .page-indicator-icon {
+  background-image: none;
+  background-color: rgba(255, 255, 255, 0.5);
+}
+.page-indicator:active .page-indicator-icon {
+  background-image: none;
+  background-color: rgba(255, 255, 255, 0.7);
+}
+.page-indicator:checked .page-indicator-icon {
+  background-image: none;
+  background-color: #FFFFFF;
+  transition-duration: 0s;
+}
 
 .app-well-app > .overview-icon.overview-icon-with-label,
 .grid-search-result .overview-icon.overview-icon-with-label {
   padding: 10px 8px 5px 8px;
-  spacing: 4px; }
+  spacing: 4px;
+}
 
 .workspace-thumbnails {
   visible-width: 32px;
   spacing: 11px;
   padding: 8px;
-  border-radius: 0; }
-  .workspace-thumbnails:rtl {
-    border-radius: 0; }
+  border-radius: 0;
+}
+.workspace-thumbnails:rtl {
+  border-radius: 0;
+}
 
 .workspace-thumbnail-indicator {
   border: 4px solid rgba(76, 86, 106, 0.8);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  padding: 0; }
+  padding: 0;
+}
 
 .search-display > StBoxLayout,
 .all-apps,
 .frequent-apps > StBoxLayout {
-  padding: 0px 88px 10px 88px; }
+  padding: 0px 88px 10px 88px;
+}
 
 .workspace-thumbnails {
   color: #d8dee9;
   background-color: transparent;
-  border: none; }
+  border: none;
+}
 
 .search-statustext, .no-frequent-applications-label {
   font-size: 2em;
   font-weight: bold;
-  color: #d8dee9; }
+  color: #d8dee9;
+}
 
 /* NOTIFICATIONS & MESSAGE TRAY */
 .url-highlighter {
-  link-color: #616e88; }
+  link-color: #616e88;
+}
 
 .notification-banner {
   font-size: 11pt;
@@ -1495,35 +1829,47 @@ StScrollBar {
   color: #d8dee9;
   background-color: #2e3440;
   border: 1px solid #1f232b;
-  box-shadow: 0 1px 4px black; }
-  .notification-banner:hover {
-    background-color: rgba(46, 52, 64, 0.96); }
-  .notification-banner:focus {
-    background-color: rgba(46, 52, 64, 0.96); }
-  .notification-banner * {
-    color: #d8dee9; }
-  .notification-banner .notification-icon {
-    padding: 5px; }
-  .notification-banner .notification-content {
-    padding: 5px;
-    spacing: 5px; }
-  .notification-banner .secondary-icon {
-    icon-size: 1.09em; }
-  .notification-banner .notification-actions {
-    background-color: #2a2f3a;
-    padding-top: 2px;
-    spacing: 1px; }
-  .notification-banner .notification-button {
-    padding: 5px;
-    background-color: rgba(46, 52, 64, 0.9);
-    box-shadow: none; }
-    .notification-banner .notification-button:first-child {
-      border-radius: 0 0 0 3px; }
-    .notification-banner .notification-button:last-child {
-      border-radius: 0 0 3px 0; }
-    .notification-banner .notification-button:hover, .notification-banner .notification-buttonfocus {
-      background-color: #2a2f3a;
-      color: #4c566a; }
+  box-shadow: 0 1px 4px black;
+}
+.notification-banner:hover {
+  background-color: rgba(46, 52, 64, 0.96);
+}
+.notification-banner:focus {
+  background-color: rgba(46, 52, 64, 0.96);
+}
+.notification-banner * {
+  color: #d8dee9;
+}
+.notification-banner .notification-icon {
+  padding: 5px;
+}
+.notification-banner .notification-content {
+  padding: 5px;
+  spacing: 5px;
+}
+.notification-banner .secondary-icon {
+  icon-size: 1.09em;
+}
+.notification-banner .notification-actions {
+  background-color: #2a2f3a;
+  padding-top: 2px;
+  spacing: 1px;
+}
+.notification-banner .notification-button {
+  padding: 5px;
+  background-color: rgba(46, 52, 64, 0.9);
+  box-shadow: none;
+}
+.notification-banner .notification-button:first-child {
+  border-radius: 0 0 0 3px;
+}
+.notification-banner .notification-button:last-child {
+  border-radius: 0 0 3px 0;
+}
+.notification-banner .notification-button:hover, .notification-banner .notification-buttonfocus {
+  background-color: #2a2f3a;
+  color: #4c566a;
+}
 
 .summary-source-counter {
   font-size: 10pt;
@@ -1536,99 +1882,127 @@ StScrollBar {
   color: #d8dee9;
   border: 2px solid #d8dee9;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.5);
-  border-radius: 0.9em; }
+  border-radius: 0.9em;
+}
 
 .secondary-icon {
-  icon-size: 1.09em; }
+  icon-size: 1.09em;
+}
 
 .chat-body {
-  spacing: 5px; }
+  spacing: 5px;
+}
 
 .chat-response {
-  margin: 5px; }
+  margin: 5px;
+}
 
 .chat-log-message {
-  color: #b7c2d7; }
+  color: #b7c2d7;
+}
 
 .chat-new-group {
-  padding-top: 1em; }
+  padding-top: 1em;
+}
 
 .chat-received {
-  padding-left: 4px; }
-  .chat-received:rtl {
-    padding-left: 0px;
-    padding-right: 4px; }
+  padding-left: 4px;
+}
+.chat-received:rtl {
+  padding-left: 0px;
+  padding-right: 4px;
+}
 
 .chat-sent {
   padding-left: 18pt;
-  color: #a7b5cd; }
-  .chat-sent:rtl {
-    padding-left: 0;
-    padding-right: 18pt; }
+  color: #a7b5cd;
+}
+.chat-sent:rtl {
+  padding-left: 0;
+  padding-right: 18pt;
+}
 
 .chat-meta-message {
   padding-left: 4px;
   font-size: 9pt;
   font-weight: bold;
-  color: #97a7c4; }
-  .chat-meta-message:rtl {
-    padding-left: 0;
-    padding-right: 4px; }
+  color: #97a7c4;
+}
+.chat-meta-message:rtl {
+  padding-left: 0;
+  padding-right: 4px;
+}
 
 .hotplug-transient-box {
   spacing: 6px;
-  padding: 2px 72px 2px 12px; }
+  padding: 2px 72px 2px 12px;
+}
 
 .hotplug-notification-item {
-  padding: 2px 10px; }
-  .hotplug-notification-item:focus {
-    padding: 1px 71px 1px 11px; }
+  padding: 2px 10px;
+}
+.hotplug-notification-item:focus {
+  padding: 1px 71px 1px 11px;
+}
 
 .hotplug-notification-item-icon {
   icon-size: 24px;
-  padding: 2px 5px; }
+  padding: 2px 5px;
+}
 
 .hotplug-resident-box {
-  spacing: 8px; }
+  spacing: 8px;
+}
 
 .hotplug-resident-mount {
   spacing: 8px;
-  border-radius: 4px; }
-  .hotplug-resident-mount:hover {
-    background-color: rgba(46, 52, 64, 0.3); }
+  border-radius: 4px;
+}
+.hotplug-resident-mount:hover {
+  background-color: rgba(46, 52, 64, 0.3);
+}
 
 .hotplug-resident-mount-label {
   color: inherit;
-  padding-left: 6px; }
+  padding-left: 6px;
+}
 
 .hotplug-resident-mount-icon {
   icon-size: 24px;
-  padding-left: 6px; }
+  padding-left: 6px;
+}
 
 .hotplug-resident-eject-icon {
-  icon-size: 16px; }
+  icon-size: 16px;
+}
 
 .hotplug-resident-eject-button {
   padding: 7px;
   border-radius: 5px;
-  color: pink; }
+  color: pink;
+}
 
 /* Eeeky things */
 .magnifier-zoom-region {
-  border: 2px solid #4c566a; }
-  .magnifier-zoom-region.full-screen {
-    border-width: 0; }
+  border: 2px solid #4c566a;
+}
+.magnifier-zoom-region.full-screen {
+  border-width: 0;
+}
 
 /* On-screen Keyboard */
 #keyboard {
-  background-color: rgba(46, 52, 64, 0.65); }
+  background-color: rgba(46, 52, 64, 0.65);
+}
 
 .keyboard-layout {
   spacing: 10px;
-  padding: 10px; }
+  padding: 10px;
+}
 
 .keyboard-row {
-  spacing: 15px; }
+  spacing: 15px;
+}
 
 .keyboard-key {
   color: #d8dee9;
@@ -1642,29 +2016,34 @@ StScrollBar {
   min-width: 2em;
   font-size: 14pt;
   font-weight: bold;
-  border-radius: 5px; }
-  .keyboard-key:focus {
-    color: #4c566a;
-    text-shadow: 0 1px black;
-    icon-shadow: 0 1px black;
-    box-shadow: none;
-    border: 1px solid #1f232b; }
-  .keyboard-key:hover, .keyboard-key:checked {
-    color: #4c566a;
-    background-color: rgba(50, 57, 70, 0.95);
-    border: 1px solid #1f232b;
-    text-shadow: 0 1px black;
-    icon-shadow: 0 1px black; }
-  .keyboard-key:active {
-    color: #4c566a;
-    background-color: rgba(46, 52, 64, 0.95);
-    border: 1px solid #1f232b;
-    text-shadow: none;
-    icon-shadow: none; }
-  .keyboard-key:grayed {
-    background-color: rgba(46, 52, 64, 0.95);
-    color: #d8dee9;
-    border-color: rgba(0, 0, 0, 0.7); }
+  border-radius: 5px;
+}
+.keyboard-key:focus {
+  color: #4c566a;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+  box-shadow: none;
+  border: 1px solid #1f232b;
+}
+.keyboard-key:hover, .keyboard-key:checked {
+  color: #4c566a;
+  background-color: rgba(50, 57, 70, 0.95);
+  border: 1px solid #1f232b;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+}
+.keyboard-key:active {
+  color: #4c566a;
+  background-color: rgba(46, 52, 64, 0.95);
+  border: 1px solid #1f232b;
+  text-shadow: none;
+  icon-shadow: none;
+}
+.keyboard-key:grayed {
+  background-color: rgba(46, 52, 64, 0.95);
+  color: #d8dee9;
+  border-color: rgba(0, 0, 0, 0.7);
+}
 
 .keyboard-subkeys {
   color: white;
@@ -1675,149 +2054,188 @@ StScrollBar {
   -arrow-border-color: #d8dee9;
   -arrow-base: 20px;
   -arrow-rise: 10px;
-  -boxpointer-gap: 5px; }
+  -boxpointer-gap: 5px;
+}
 
 .candidate-popup-content {
   padding: 0.5em;
-  spacing: 0.3em; }
+  spacing: 0.3em;
+}
 
 .candidate-index {
   padding: 0 0.5em 0 0;
-  color: #b7c2d7; }
+  color: #b7c2d7;
+}
 
 .candidate-box {
   padding: 0.3em 0.5em 0.3em 0.5em;
-  border-radius: 4px; }
-  .candidate-box:selected, .candidate-box:hover {
-    background-color: #4c566a;
-    color: #d8dee9; }
+  border-radius: 4px;
+}
+.candidate-box:selected, .candidate-box:hover {
+  background-color: #4c566a;
+  color: #d8dee9;
+}
 
 .candidate-page-button-box {
-  height: 2em; }
-  .vertical .candidate-page-button-box {
-    padding-top: 0.5em; }
-  .horizontal .candidate-page-button-box {
-    padding-left: 0.5em; }
+  height: 2em;
+}
+.vertical .candidate-page-button-box {
+  padding-top: 0.5em;
+}
+.horizontal .candidate-page-button-box {
+  padding-left: 0.5em;
+}
 
 .candidate-page-button {
-  padding: 4px; }
+  padding: 4px;
+}
 
 .candidate-page-button-previous {
   border-radius: 4px 0px 0px 4px;
-  border-right-width: 0; }
+  border-right-width: 0;
+}
 
 .candidate-page-button-next {
-  border-radius: 0px 4px 4px 0px; }
+  border-radius: 0px 4px 4px 0px;
+}
 
 .candidate-page-button-icon {
-  icon-size: 1em; }
+  icon-size: 1em;
+}
 
 /* Auth Dialogs & Screen Shield */
 .framed-user-icon {
   background-size: contain;
   border: 2px solid #d8dee9;
   color: #d8dee9;
-  border-radius: 3px; }
-  .framed-user-icon:hover {
-    border-color: white;
-    color: white; }
+  border-radius: 3px;
+}
+.framed-user-icon:hover {
+  border-color: white;
+  color: white;
+}
 
 .login-dialog-banner-view {
   padding-top: 24px;
-  max-width: 23em; }
+  max-width: 23em;
+}
 
 .login-dialog {
   border: none;
-  background-color: transparent; }
-  .login-dialog .modal-dialog-button-box {
-    spacing: 3px; }
-  .login-dialog .modal-dialog-button {
-    padding: 3px 18px; }
-    .login-dialog .modal-dialog-button:default {
-      color: #d8dee9;
-      background-color: #232831;
-      box-shadow: none;
-      border: 1px solid #1f232b;
-      text-shadow: 0 1px black;
-      icon-shadow: 0 1px black; }
-      .login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus {
-        color: #4c566a;
-        background-color: rgba(76, 86, 106, 0.7);
-        border: 1px solid #1f232b;
-        text-shadow: 0 1px black;
-        icon-shadow: 0 1px black; }
-      .login-dialog .modal-dialog-button:default:active {
-        color: #4c566a;
-        background-color: #4c566a;
-        border: 1px solid #1f232b;
-        text-shadow: none;
-        icon-shadow: none; }
-      .login-dialog .modal-dialog-button:default:insensitive {
-        color: #838995;
-        background-color: rgba(64, 70, 82, 0.66);
-        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-        border: none;
-        text-shadow: none;
-        icon-shadow: none; }
+  background-color: transparent;
+}
+.login-dialog .modal-dialog-button-box {
+  spacing: 3px;
+}
+.login-dialog .modal-dialog-button {
+  padding: 3px 18px;
+}
+.login-dialog .modal-dialog-button:default {
+  color: #d8dee9;
+  background-color: #232831;
+  box-shadow: none;
+  border: 1px solid #1f232b;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+}
+.login-dialog .modal-dialog-button:default:hover, .login-dialog .modal-dialog-button:default:focus {
+  color: #4c566a;
+  background-color: rgba(76, 86, 106, 0.7);
+  border: 1px solid #1f232b;
+  text-shadow: 0 1px black;
+  icon-shadow: 0 1px black;
+}
+.login-dialog .modal-dialog-button:default:active {
+  color: #4c566a;
+  background-color: #4c566a;
+  border: 1px solid #1f232b;
+  text-shadow: none;
+  icon-shadow: none;
+}
+.login-dialog .modal-dialog-button:default:insensitive {
+  color: #838995;
+  background-color: rgba(64, 70, 82, 0.66);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  border: none;
+  text-shadow: none;
+  icon-shadow: none;
+}
 
 .login-dialog-logo-bin {
-  padding: 24px 0px; }
+  padding: 24px 0px;
+}
 
 .login-dialog-banner {
-  color: #b7c2d7; }
+  color: #b7c2d7;
+}
 
 .login-dialog-button-box {
-  spacing: 5px; }
+  spacing: 5px;
+}
 
 .login-dialog-message-warning {
-  color: #c3674a; }
+  color: #c3674a;
+}
 
 .login-dialog-message-hint {
   padding-top: 0;
-  padding-bottom: 20px; }
+  padding-bottom: 20px;
+}
 
 .login-dialog-user-selection-box {
-  padding: 100px 0px; }
+  padding: 100px 0px;
+}
 
 .login-dialog-not-listed-label {
-  padding-left: 2px; }
-  .login-dialog-not-listed-button:focus .login-dialog-not-listed-label,
-  .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
-    color: #d8dee9; }
+  padding-left: 2px;
+}
+.login-dialog-not-listed-button:focus .login-dialog-not-listed-label, .login-dialog-not-listed-button:hover .login-dialog-not-listed-label {
+  color: #d8dee9;
+}
 
 .login-dialog-not-listed-label {
   font-size: 90%;
   font-weight: bold;
   color: #768bb2;
-  padding-top: 1em; }
+  padding-top: 1em;
+}
 
 .login-dialog-user-list-view {
-  -st-vfade-offset: 1em; }
+  -st-vfade-offset: 1em;
+}
 
 .login-dialog-user-list {
   spacing: 12px;
-  padding: .2em;
-  width: 23em; }
-  .login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
-    background-color: #4c566a;
-    color: #d8dee9; }
-  .login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
-    border-right: 2px solid #4c566a; }
+  padding: 0.2em;
+  width: 23em;
+}
+.login-dialog-user-list:expanded .login-dialog-user-list-item:selected {
+  background-color: #4c566a;
+  color: #d8dee9;
+}
+.login-dialog-user-list:expanded .login-dialog-user-list-item:logged-in {
+  border-right: 2px solid #4c566a;
+}
 
 .login-dialog-user-list-item {
   border-radius: 5px;
-  padding: .2em;
-  color: #768bb2; }
-  .login-dialog-user-list-item:ltr {
-    padding-right: 1em; }
-  .login-dialog-user-list-item:rtl {
-    padding-left: 1em; }
-  .login-dialog-user-list-item .login-dialog-timed-login-indicator {
-    height: 2px;
-    margin: 2px 0 0 0;
-    background-color: #d8dee9; }
-  .login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
-    background-color: #d8dee9; }
+  padding: 0.2em;
+  color: #768bb2;
+}
+.login-dialog-user-list-item:ltr {
+  padding-right: 1em;
+}
+.login-dialog-user-list-item:rtl {
+  padding-left: 1em;
+}
+.login-dialog-user-list-item .login-dialog-timed-login-indicator {
+  height: 2px;
+  margin: 2px 0 0 0;
+  background-color: #d8dee9;
+}
+.login-dialog-user-list-item:focus .login-dialog-timed-login-indicator {
+  background-color: #d8dee9;
+}
 
 .login-dialog-username,
 .user-widget-label {
@@ -1825,181 +2243,226 @@ StScrollBar {
   font-size: 120%;
   font-weight: bold;
   text-align: left;
-  padding-left: 15px; }
+  padding-left: 15px;
+}
 
 .user-widget-label:ltr {
-  padding-left: 18px; }
-
+  padding-left: 18px;
+}
 .user-widget-label:rtl {
-  padding-right: 18px; }
+  padding-right: 18px;
+}
 
 .login-dialog-prompt-layout {
   padding-top: 24px;
   padding-bottom: 12px;
   spacing: 8px;
-  width: 23em; }
+  width: 23em;
+}
 
 .login-dialog-prompt-label {
   color: #97a7c4;
   font-size: 110%;
-  padding-top: 1em; }
+  padding-top: 1em;
+}
 
 .login-dialog-session-list-button StIcon {
-  icon-size: 1.25em; }
+  icon-size: 1.25em;
+}
 
 .login-dialog-session-list-button {
-  color: #768bb2; }
-  .login-dialog-session-list-button:hover, .login-dialog-session-list-button:focus {
-    color: #d8dee9; }
-  .login-dialog-session-list-button:active {
-    color: #46597c; }
+  color: #768bb2;
+}
+.login-dialog-session-list-button:hover, .login-dialog-session-list-button:focus {
+  color: #d8dee9;
+}
+.login-dialog-session-list-button:active {
+  color: #46597c;
+}
 
 .screen-shield-arrows {
-  padding-bottom: 3em; }
+  padding-bottom: 3em;
+}
 
 .screen-shield-arrows Gjs_Arrow {
   color: white;
   width: 80px;
   height: 48px;
   -arrow-thickness: 12px;
-  -arrow-shadow: 0 1px 1px rgba(0, 0, 0, 0.4); }
+  -arrow-shadow: 0 1px 1px rgba(0, 0, 0, 0.4);
+}
 
 .screen-shield-clock {
   color: white;
   text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.6);
   font-weight: bold;
   text-align: center;
-  padding-bottom: 1.5em; }
+  padding-bottom: 1.5em;
+}
 
 .screen-shield-clock-time {
   font-size: 72pt;
-  text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.4); }
+  text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.4);
+}
 
 .screen-shield-clock-date {
-  font-size: 28pt; }
+  font-size: 28pt;
+}
 
 .screen-shield-notifications-container {
   spacing: 6px;
   width: 30em;
   background-color: transparent;
-  max-height: 500px; }
-  .screen-shield-notifications-container .summary-notification-stack-scrollview {
-    padding-top: 0;
-    padding-bottom: 0; }
-  .screen-shield-notifications-container .notification,
-  .screen-shield-notifications-container .screen-shield-notification-source {
-    padding: 12px 6px;
-    border: 1px solid #d8dee9;
-    background-color: rgba(46, 52, 64, 0.45);
-    color: #d8dee9;
-    border-radius: 4px; }
-  .screen-shield-notifications-container .notification {
-    margin-right: 15px; }
+  max-height: 500px;
+}
+.screen-shield-notifications-container .summary-notification-stack-scrollview {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.screen-shield-notifications-container .notification,
+.screen-shield-notifications-container .screen-shield-notification-source {
+  padding: 12px 6px;
+  border: 1px solid #d8dee9;
+  background-color: rgba(46, 52, 64, 0.45);
+  color: #d8dee9;
+  border-radius: 4px;
+}
+.screen-shield-notifications-container .notification {
+  margin-right: 15px;
+}
 
 .screen-shield-notification-label {
   font-weight: bold;
-  padding: 0px 0px 0px 12px; }
+  padding: 0px 0px 0px 12px;
+}
 
 .screen-shield-notification-count-text {
-  padding: 0px 0px 0px 12px; }
+  padding: 0px 0px 0px 12px;
+}
 
 #panel.lock-screen {
-  background-color: rgba(46, 52, 64, 0.45); }
+  background-color: rgba(46, 52, 64, 0.45);
+}
 
 .screen-shield-background {
   background: black;
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.4); }
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.4);
+}
 
 #lockDialogGroup {
   background: #2e3436 url(resource:///org/gnome/shell/theme/noise-texture.png);
-  background-repeat: repeat; }
+  background-repeat: repeat;
+}
 
 #screenShieldNotifications StButton#vhandle, #screenShieldNotifications StButton#hhandle {
-  background-color: rgba(46, 52, 64, 0.3); }
-  #screenShieldNotifications StButton#vhandle:hover, #screenShieldNotifications StButton#vhandle:focus, #screenShieldNotifications StButton#hhandle:hover, #screenShieldNotifications StButton#hhandle:focus {
-    background-color: rgba(46, 52, 64, 0.5); }
-  #screenShieldNotifications StButton#vhandle:active, #screenShieldNotifications StButton#hhandle:active {
-    background-color: rgba(76, 86, 106, 0.5); }
+  background-color: rgba(46, 52, 64, 0.3);
+}
+#screenShieldNotifications StButton#vhandle:hover, #screenShieldNotifications StButton#vhandle:focus, #screenShieldNotifications StButton#hhandle:hover, #screenShieldNotifications StButton#hhandle:focus {
+  background-color: rgba(46, 52, 64, 0.5);
+}
+#screenShieldNotifications StButton#vhandle:active, #screenShieldNotifications StButton#hhandle:active {
+  background-color: rgba(76, 86, 106, 0.5);
+}
 
 #LookingGlassDialog {
   background-color: rgba(0, 0, 0, 0.8);
   spacing: 4px;
   padding: 4px;
   border: 2px solid grey;
-  border-radius: 4px; }
-  #LookingGlassDialog > #Toolbar {
-    border: 1px solid grey;
-    border-radius: 4px; }
-  #LookingGlassDialog .labels {
-    spacing: 4px; }
-  #LookingGlassDialog .notebook-tab {
-    -natural-hpadding: 12px;
-    -minimum-hpadding: 6px;
-    font-weight: bold;
-    color: #ccc;
-    transition-duration: 100ms;
-    padding-left: .3em;
-    padding-right: .3em; }
-    #LookingGlassDialog .notebook-tab:hover {
-      color: white;
-      text-shadow: black 0px 2px 2px; }
-    #LookingGlassDialog .notebook-tab:selected {
-      border-bottom-width: 2px;
-      border-color: #576279;
-      color: white;
-      text-shadow: black 0px 2px 2px; }
-  #LookingGlassDialog StBoxLayout#EvalBox {
-    padding: 4px;
-    spacing: 4px; }
-  #LookingGlassDialog StBoxLayout#ResultsArea {
-    spacing: 4px; }
+  border-radius: 4px;
+}
+#LookingGlassDialog > #Toolbar {
+  border: 1px solid grey;
+  border-radius: 4px;
+}
+#LookingGlassDialog .labels {
+  spacing: 4px;
+}
+#LookingGlassDialog .notebook-tab {
+  -natural-hpadding: 12px;
+  -minimum-hpadding: 6px;
+  font-weight: bold;
+  color: #ccc;
+  transition-duration: 100ms;
+  padding-left: 0.3em;
+  padding-right: 0.3em;
+}
+#LookingGlassDialog .notebook-tab:hover {
+  color: white;
+  text-shadow: black 0px 2px 2px;
+}
+#LookingGlassDialog .notebook-tab:selected {
+  border-bottom-width: 2px;
+  border-color: #576279;
+  color: white;
+  text-shadow: black 0px 2px 2px;
+}
+#LookingGlassDialog StBoxLayout#EvalBox {
+  padding: 4px;
+  spacing: 4px;
+}
+#LookingGlassDialog StBoxLayout#ResultsArea {
+  spacing: 4px;
+}
 
 .lg-dialog StEntry {
   selection-background-color: #bbbbbb;
-  selected-color: #333333; }
-
+  selected-color: #333333;
+}
 .lg-dialog .shell-link {
-  color: #999999; }
-  .lg-dialog .shell-link:hover {
-    color: #dddddd; }
+  color: #999999;
+}
+.lg-dialog .shell-link:hover {
+  color: #dddddd;
+}
 
 .lg-completions-text {
-  font-size: .9em;
-  font-style: italic; }
+  font-size: 0.9em;
+  font-style: italic;
+}
 
 .lg-obj-inspector-title {
-  spacing: 4px; }
+  spacing: 4px;
+}
 
 .lg-obj-inspector-button {
   border: 1px solid gray;
   padding: 4px;
-  border-radius: 4px; }
-  .lg-obj-inspector-button:hover {
-    border: 1px solid #ffffff; }
+  border-radius: 4px;
+}
+.lg-obj-inspector-button:hover {
+  border: 1px solid #ffffff;
+}
 
 #lookingGlassExtensions {
-  padding: 4px; }
+  padding: 4px;
+}
 
 .lg-extensions-list {
   padding: 4px;
-  spacing: 6px; }
+  spacing: 6px;
+}
 
 .lg-extension {
   border: 1px solid #6f6f6f;
   border-radius: 4px;
-  padding: 4px; }
+  padding: 4px;
+}
 
 .lg-extension-name {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .lg-extension-meta {
-  spacing: 6px; }
+  spacing: 6px;
+}
 
 #LookingGlassPropertyInspector {
   background: rgba(0, 0, 0, 0.8);
   border: 2px solid grey;
   border-radius: 4px;
-  padding: 6px; }
+  padding: 6px;
+}
 
 .openweather-current-summarybox,
 .openweather-forecast-icon,
@@ -2008,7 +2471,46 @@ StScrollBar {
 .openweather-current-icon,
 .openweather-forecast-summary,
 .openweather-forecast-temperature {
-  background: transparent; }
+  background: transparent;
+}
 
 .openweather-current-databox-captions, .openweather-forecast-day {
-  color: #4c566a; }
+  color: #4c566a;
+}
+
+/* Pop_OS COSMIC Widget styling. */
+/* Pop_OS COSMIC Dock styling, append !important to any changed rules */
+.cosmic-dock #dock {
+  border-radius: 12px 12px 12px 12px !important;
+  border: 0px solid rgba(255, 255, 255, 0.16);
+  background-color: #2e3440;
+  margin: 4px !important;
+}
+
+.cosmic-dock.extended #dock {
+  border-radius: 0px !important;
+  margin: 0 !important;
+}
+
+.cosmic-dock.extended.side #dock {
+  border-top-width: 0 !important;
+  border-bottom-width: 0 !important;
+}
+
+.cosmic-dock.extended.side.left #dock {
+  border-left-width: 0 !important;
+}
+
+.cosmic-dock.extended.side.right #dock {
+  border-right-width: 0 !important;
+}
+
+.cosmic-dock.extended.bottom #dock {
+  border-bottom-width: 0 !important;
+  border-left-width: 0 !important;
+  border-right-width: 0 !important;
+}
+
+.cosmic-dock .app-well-app:hover .overview-icon, .cosmic-dock .app-well-app:focus .overview-icon, .cosmic-dock .app-well-app:selected .overview-icon {
+  border-radius: 11px;
+}

--- a/gnome-shell/gnome-shell.scss
+++ b/gnome-shell/gnome-shell.scss
@@ -3,4 +3,6 @@ $subtheme: 'main';
 @import "colors"; //use gtk colors
 @import "drawing";
 @import "common";
-@import "extensions"
+@import "extensions";
+
+@import "cosmic";


### PR DESCRIPTION
### Implement styles for new pop_os 21.04 cosmic visual elements 
- modify  cosmic dock background color to nord0
- change applications/overview background color to match the topbar background-color
# Concerns
- is the current location of `_cosmic.scss` in line with how you want to organize the files?
- should this be moved from the darker branch to the master branch? could @EliverLara give me a quick explanation of the branch structure?
### Before
![image](https://user-images.githubusercontent.com/48167848/124363661-6d29f680-dbf1-11eb-8ecc-72421abc629c.png)

### After
![image](https://user-images.githubusercontent.com/48167848/124363612-220fe380-dbf1-11eb-94a6-84ffee66181b.png)
