### PR TITLE
Xfce: Improve appmenu plugin text color

### DIFF
--- a/gtk-3.0/apps/_xfce.scss
+++ b/gtk-3.0/apps/_xfce.scss
@@ -55,3 +55,9 @@
         background-color: $selected_bg_color;
     }
 }
+
+.-vala-panel-appmenu-core scrolledwindow,
+.-vala-panel-appmenu-private > menuitem,
+.-vala-panel-appmenu-private > menuitem:first-child > label {
+    color: $panel_fg_color;
+}

--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -5832,6 +5832,11 @@ radiobutton.color-button:active > radio {
   #whiskermenu-window button:hover, #whiskermenu-window button:checked {
     background-color: #8fbcbb; }
 
+.-vala-panel-appmenu-core scrolledwindow,
+.-vala-panel-appmenu-private > menuitem,
+.-vala-panel-appmenu-private > menuitem:first-child > label {
+    color: #d8dee9; }
+
 /********
 * Unity *
 *********/


### PR DESCRIPTION
### **Improve appmenu plugin text color on Xfce**

- Modify vala-panel-appmenu text color from inherit to $panel_fg_color

### **Before**
![image](https://user-images.githubusercontent.com/68300628/185790806-206a0cc4-469c-4e2d-a616-4d7f3c1915cf.png)

### **After**
![image](https://user-images.githubusercontent.com/68300628/185790831-ef971ef8-04e8-48f2-b821-7b4cf4667de6.png)
