### PR TITLE
KDE: Fix color scheme name

### DIFF
--- a/kde/plasma/look-and-feel/Nordic-bluish/contents/defaults
+++ b/kde/plasma/look-and-feel/Nordic-bluish/contents/defaults
@@ -2,7 +2,7 @@
 widgetStyle=kvantum
 
 [kdeglobals][General]
-ColorScheme=nordic-bluish
+ColorScheme=nordicbluish
 
 [kdeglobals][Icons]
 Theme=Nordic-bluish

--- a/kde/plasma/look-and-feel/Nordic-darker/contents/defaults
+++ b/kde/plasma/look-and-feel/Nordic-darker/contents/defaults
@@ -2,7 +2,7 @@
 widgetStyle=kvantum
 
 [kdeglobals][General]
-ColorScheme=Nordic-Darker
+ColorScheme=NordicDarker
 
 [kdeglobals][Icons]
 Theme=Nordic-darker


### PR DESCRIPTION
KDE can't find the color scheme name because color names shouldn't have hyphens