### PR TITLE
fix(gtk4): replace deprecated -gtk-scaled() with plain url() for GTK 4.22+

### DIFF
--- a/gtk-4.0/gtk-dark.css
+++ b/gtk-4.0/gtk-dark.css
@@ -1154,369 +1154,369 @@ calendar {
  * Check and Radio Items *
  *************************/
 check {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-dark.png"), url("../assets/radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-hover-dark.png"), url("../assets/checkbox-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-hover-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-hover-dark.png"), url("../assets/radio-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-hover-dark.png");
   -gtk-icon-shadow: none; }
 
 check:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-active-dark.png"), url("../assets/checkbox-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-active-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-active-dark.png"), url("../assets/radio-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-active-dark.png");
   -gtk-icon-shadow: none; }
 
 check:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-backdrop-dark.png"), url("../assets/checkbox-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-backdrop-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-backdrop-dark.png"), url("../assets/radio-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-backdrop-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-insensitive-dark.png"), url("../assets/checkbox-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-insensitive-dark.png"), url("../assets/radio-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-insensitive-dark.png"), url("../assets/checkbox-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-insensitive-dark.png"), url("../assets/radio-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-dark.png"), url("../assets/radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-hover-dark.png"), url("../assets/checkbox-checked-hover@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-hover-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-hover-dark.png"), url("../assets/radio-checked-hover@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-hover-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-active-dark.png"), url("../assets/checkbox-checked-active@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-active-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-active-dark.png"), url("../assets/radio-checked-active@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-active-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-backdrop-dark.png"), url("../assets/checkbox-checked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-backdrop-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-backdrop-dark.png"), url("../assets/radio-checked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-backdrop-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-insensitive-dark.png"), url("../assets/checkbox-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-insensitive-dark.png"), url("../assets/radio-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-insensitive-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-insensitive-dark.png"), url("../assets/checkbox-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-insensitive-dark.png"), url("../assets/radio-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-insensitive-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:indeterminate {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed.png"), url("../assets/checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed.png"), url("../assets/radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-hover.png"), url("../assets/checkbox-mixed-hover@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-hover.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-hover.png"), url("../assets/radio-mixed-hover@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-hover.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-active.png"), url("../assets/checkbox-mixed-active@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-active.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-active.png"), url("../assets/radio-mixed-active@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-active.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-backdrop.png"), url("../assets/checkbox-mixed-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-backdrop.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-backdrop.png"), url("../assets/radio-mixed-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-backdrop.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-insensitive.png"), url("../assets/checkbox-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-insensitive.png"), url("../assets/radio-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-insensitive.png"), url("../assets/checkbox-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-insensitive.png"), url("../assets/radio-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 check:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check, iconview.content-view check,
 .view.content-view.check,
 iconview.content-view.check {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio, iconview.content-view radio,
 .view.content-view.radio,
 iconview.content-view.radio {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked.png"), url("../assets/radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:hover, iconview.content-view check:hover,
 .view.content-view.check:hover,
 iconview.content-view.check:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-hover.png"), url("../assets/checkbox-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-hover.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:hover, iconview.content-view radio:hover,
 .view.content-view.radio:hover,
 iconview.content-view.radio:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-hover.png"), url("../assets/radio-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-hover.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:active, iconview.content-view check:active,
 .view.content-view.check:active,
 iconview.content-view.check:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-active.png"), url("../assets/checkbox-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-active.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:active, iconview.content-view radio:active,
 .view.content-view.radio:active,
 iconview.content-view.radio:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-active.png"), url("../assets/radio-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-active.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:backdrop, iconview.content-view check:backdrop,
 .view.content-view.check:backdrop,
 iconview.content-view.check:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-backdrop.png"), url("../assets/checkbox-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-backdrop.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:backdrop, iconview.content-view radio:backdrop,
 .view.content-view.radio:backdrop,
 iconview.content-view.radio:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-backdrop.png"), url("../assets/radio-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-backdrop.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:disabled, iconview.content-view check:disabled,
 .view.content-view.check:disabled,
 iconview.content-view.check:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-insensitive.png"), url("../assets/checkbox-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-insensitive.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:disabled, iconview.content-view radio:disabled,
 .view.content-view.radio:disabled,
 iconview.content-view.radio:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-insensitive.png"), url("../assets/radio-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-insensitive.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:disabled:backdrop, iconview.content-view check:disabled:backdrop,
 .view.content-view.check:disabled:backdrop,
 iconview.content-view.check:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-backdrop-insensitive.png"), url("../assets/checkbox-unchecked-backdrop-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-backdrop-insensitive.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:disabled:backdrop, iconview.content-view radio:disabled:backdrop,
 .view.content-view.radio:disabled:backdrop,
 iconview.content-view.radio:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-backdrop-insensitive.png"), url("../assets/radio-unchecked-backdrop-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-backdrop-insensitive.png");
   -gtk-icon-shadow: none; }
 
 checkbutton.text-button, radiobutton.text-button {
@@ -4376,35 +4376,35 @@ switch {
   background-size: 40px 24px;
   background-repeat: no-repeat;
   background-position: center center;
-  background-image: -gtk-scaled(url("../assets/switch-off.svg"), url("../assets/switch-off.svg")); }
+  background-image: url("../assets/switch-off.svg"); }
   switch:disabled {
-    background-image: -gtk-scaled(url("../assets/switch-insensitive.svg"), url("../assets/switch-insensitive.svg")); }
+    background-image: url("../assets/switch-insensitive.svg"); }
     switch:disabled slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-insensitive.svg"), url("../assets/switch-slider-insensitive@2.png")); }
+      background-image: url("../assets/switch-slider-insensitive.svg"); }
   switch, switch slider {
     outline-color: transparent;
     color: transparent;
     border: none;
     box-shadow: none; }
   switch:checked {
-    background-image: -gtk-scaled(url("../assets/switch-on.svg"), url("../assets/switch-on.svg")); }
+    background-image: url("../assets/switch-on.svg"); }
     switch:checked slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-on.svg"), url("../assets/switch-slider-on@2.png")); }
+      background-image: url("../assets/switch-slider-on.svg"); }
     switch:checked:disabled {
-      background-image: -gtk-scaled(url("../assets/switch-on-insensitive.svg"), url("../assets/switch-on-insensitive.svg")); }
+      background-image: url("../assets/switch-on-insensitive.svg"); }
       switch:checked:disabled slider {
-        background-image: -gtk-scaled(url("../assets/switch-slider-on-insensitive.svg"), url("../assets/switch-slider-on-insensitive@2.png")); }
+        background-image: url("../assets/switch-slider-on-insensitive.svg"); }
   switch slider {
     min-width: 1px;
     min-height: 1px;
     background-repeat: no-repeat;
     background-position: left center;
     background-color: transparent;
-    background-image: -gtk-scaled(url("../assets/switch-slider-off.svg"), url("../assets/switch-slider-off@2.png")); }
+    background-image: url("../assets/switch-slider-off.svg"); }
   row:selected switch:checked {
-    background-image: -gtk-scaled(url("../assets/switch-off.svg"), url("../assets/switch-off.svg")); }
+    background-image: url("../assets/switch-off.svg"); }
     row:selected switch:checked slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-on-selected.svg"), url("../assets/switch-slider-on-selected@2.png")); }
+      background-image: url("../assets/switch-slider-on-selected.svg"); }
   switch trough:active, switch trough:checked {
     background-color: #8fbcbb; }
     switch trough:active:backdrop, switch trough:checked:backdrop {
@@ -4690,20 +4690,20 @@ windowcontrols button.close, windowcontrols button.maximize, windowcontrols butt
     box-shadow: none;
     color: transparent; }
 windowcontrols button.close {
-  background-image: -gtk-scaled(url("../assets/close.png"), url("../assets/close@2.png")); }
+  background-image: url("../assets/close.png"); }
   windowcontrols button.close:hover, windowcontrols button.close:active {
-    background-image: -gtk-scaled(url("../assets/close_prelight.png"), url("../assets/close_prelight@2.png")); }
+    background-image: url("../assets/close_prelight.png"); }
 windowcontrols button.maximize {
-  background-image: -gtk-scaled(url("../assets/maximize.png"), url("../assets/maximize@2.png")); }
+  background-image: url("../assets/maximize.png"); }
   windowcontrols button.maximize:hover, windowcontrols button.maximize:active {
-    background-image: -gtk-scaled(url("../assets/maximize_prelight.png"), url("../assets/maximize_prelight@2.png")); }
+    background-image: url("../assets/maximize_prelight.png"); }
 windowcontrols button.minimize {
-  background-image: -gtk-scaled(url("../assets/min.png"), url("../assets/min@2.png")); }
+  background-image: url("../assets/min.png"); }
   windowcontrols button.minimize:hover, windowcontrols button.minimize:active {
-    background-image: -gtk-scaled(url("../assets/min_prelight.png"), url("../assets/min_prelight@2.png")); }
+    background-image: url("../assets/min_prelight.png"); }
 windowcontrols button:backdrop {
   -gtk-icon-shadow: none;
-  background-image: -gtk-scaled(url("../assets/close_unfocused.png"), url("../assets/close_unfocused@2.png")); }
+  background-image: url("../assets/close_unfocused.png"); }
 
 headerbar.selection-mode button.titlebutton,
 .titlebar.selection-mode button.titlebutton {

--- a/gtk-4.0/gtk.css
+++ b/gtk-4.0/gtk.css
@@ -1154,369 +1154,369 @@ calendar {
  * Check and Radio Items *
  *************************/
 check {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-dark.png"), url("../assets/radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-hover-dark.png"), url("../assets/checkbox-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-hover-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-hover-dark.png"), url("../assets/radio-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-hover-dark.png");
   -gtk-icon-shadow: none; }
 
 check:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-active-dark.png"), url("../assets/checkbox-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-active-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-active-dark.png"), url("../assets/radio-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-active-dark.png");
   -gtk-icon-shadow: none; }
 
 check:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-backdrop-dark.png"), url("../assets/checkbox-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-backdrop-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-backdrop-dark.png"), url("../assets/radio-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-backdrop-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-insensitive-dark.png"), url("../assets/checkbox-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-insensitive-dark.png"), url("../assets/radio-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-insensitive-dark.png"), url("../assets/checkbox-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-unchecked-insensitive-dark.png"), url("../assets/radio-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-unchecked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-dark.png"), url("../assets/radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-hover-dark.png"), url("../assets/checkbox-checked-hover@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-hover-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-hover-dark.png"), url("../assets/radio-checked-hover@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-hover-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-active-dark.png"), url("../assets/checkbox-checked-active@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-active-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-active-dark.png"), url("../assets/radio-checked-active@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-active-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-backdrop-dark.png"), url("../assets/checkbox-checked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-backdrop-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-backdrop-dark.png"), url("../assets/radio-checked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-backdrop-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-insensitive-dark.png"), url("../assets/checkbox-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-insensitive-dark.png"), url("../assets/radio-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-insensitive-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:checked:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-insensitive-dark.png"), url("../assets/checkbox-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-insensitive-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-checked-insensitive-dark.png"), url("../assets/radio-checked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-checked-insensitive-dark.png");
   -gtk-icon-shadow: none;
   background: none; }
 
 check:indeterminate {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed.png"), url("../assets/checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed.png"), url("../assets/radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-hover.png"), url("../assets/checkbox-mixed-hover@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-hover.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-hover.png"), url("../assets/radio-mixed-hover@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-hover.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-active.png"), url("../assets/checkbox-mixed-active@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-active.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-active.png"), url("../assets/radio-mixed-active@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-active.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-backdrop.png"), url("../assets/checkbox-mixed-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-backdrop.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-backdrop.png"), url("../assets/radio-mixed-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-backdrop.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-insensitive.png"), url("../assets/checkbox-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-insensitive.png"), url("../assets/radio-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-mixed-insensitive.png"), url("../assets/checkbox-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/radio-mixed-insensitive.png"), url("../assets/radio-mixed-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/radio-mixed-insensitive.png");
   -gtk-icon-shadow: none; }
 
 check:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-unchecked-dark.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-unchecked-dark.png"), url("../assets/selected-radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-unchecked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:checked:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/checkbox-checked-dark.png"), url("../assets/checkbox-checked@2.png"));
+  -gtk-icon-source: url("../assets/checkbox-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 radio:checked:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-checked-dark.png"), url("../assets/selected-radio-checked@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-checked-dark.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:hover:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:active:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 check:indeterminate:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-checkbox-mixed.png"), url("../assets/selected-checkbox-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-checkbox-mixed.png");
   -gtk-icon-shadow: none; }
 
 radio:indeterminate:disabled:backdrop:selected {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selected-radio-mixed.png"), url("../assets/selected-radio-mixed@2.png"));
+  -gtk-icon-source: url("../assets/selected-radio-mixed.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check, iconview.content-view check,
 .view.content-view.check,
 iconview.content-view.check {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked.png"), url("../assets/checkbox-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio, iconview.content-view radio,
 .view.content-view.radio,
 iconview.content-view.radio {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked.png"), url("../assets/radio-unchecked@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:hover, iconview.content-view check:hover,
 .view.content-view.check:hover,
 iconview.content-view.check:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-hover.png"), url("../assets/checkbox-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-hover.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:hover, iconview.content-view radio:hover,
 .view.content-view.radio:hover,
 iconview.content-view.radio:hover {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-hover.png"), url("../assets/radio-unchecked-hover@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-hover.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:active, iconview.content-view check:active,
 .view.content-view.check:active,
 iconview.content-view.check:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-active.png"), url("../assets/checkbox-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-active.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:active, iconview.content-view radio:active,
 .view.content-view.radio:active,
 iconview.content-view.radio:active {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-active.png"), url("../assets/radio-unchecked-active@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-active.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:backdrop, iconview.content-view check:backdrop,
 .view.content-view.check:backdrop,
 iconview.content-view.check:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-backdrop.png"), url("../assets/checkbox-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-backdrop.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:backdrop, iconview.content-view radio:backdrop,
 .view.content-view.radio:backdrop,
 iconview.content-view.radio:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-backdrop.png"), url("../assets/radio-unchecked-backdrop@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-backdrop.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:disabled, iconview.content-view check:disabled,
 .view.content-view.check:disabled,
 iconview.content-view.check:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-insensitive.png"), url("../assets/checkbox-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-insensitive.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:disabled, iconview.content-view radio:disabled,
 .view.content-view.radio:disabled,
 iconview.content-view.radio:disabled {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-insensitive.png"), url("../assets/radio-unchecked-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-insensitive.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view check:disabled:backdrop, iconview.content-view check:disabled:backdrop,
 .view.content-view.check:disabled:backdrop,
 iconview.content-view.check:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox-unchecked-backdrop-insensitive.png"), url("../assets/checkbox-unchecked-backdrop-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-checkbox-unchecked-backdrop-insensitive.png");
   -gtk-icon-shadow: none; }
 
 .view.content-view radio:disabled:backdrop, iconview.content-view radio:disabled:backdrop,
 .view.content-view.radio:disabled:backdrop,
 iconview.content-view.radio:disabled:backdrop {
-  -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio-unchecked-backdrop-insensitive.png"), url("../assets/radio-unchecked-backdrop-insensitive@2.png"));
+  -gtk-icon-source: url("../assets/selection-mode-radio-unchecked-backdrop-insensitive.png");
   -gtk-icon-shadow: none; }
 
 checkbutton.text-button, radiobutton.text-button {
@@ -4376,35 +4376,35 @@ switch {
   background-size: 40px 24px;
   background-repeat: no-repeat;
   background-position: center center;
-  background-image: -gtk-scaled(url("../assets/switch-off.svg"), url("../assets/switch-off.svg")); }
+  background-image: url("../assets/switch-off.svg"); }
   switch:disabled {
-    background-image: -gtk-scaled(url("../assets/switch-insensitive.svg"), url("../assets/switch-insensitive.svg")); }
+    background-image: url("../assets/switch-insensitive.svg"); }
     switch:disabled slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-insensitive.svg"), url("../assets/switch-slider-insensitive@2.png")); }
+      background-image: url("../assets/switch-slider-insensitive.svg"); }
   switch, switch slider {
     outline-color: transparent;
     color: transparent;
     border: none;
     box-shadow: none; }
   switch:checked {
-    background-image: -gtk-scaled(url("../assets/switch-on.svg"), url("../assets/switch-on.svg")); }
+    background-image: url("../assets/switch-on.svg"); }
     switch:checked slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-on.svg"), url("../assets/switch-slider-on@2.png")); }
+      background-image: url("../assets/switch-slider-on.svg"); }
     switch:checked:disabled {
-      background-image: -gtk-scaled(url("../assets/switch-on-insensitive.svg"), url("../assets/switch-on-insensitive.svg")); }
+      background-image: url("../assets/switch-on-insensitive.svg"); }
       switch:checked:disabled slider {
-        background-image: -gtk-scaled(url("../assets/switch-slider-on-insensitive.svg"), url("../assets/switch-slider-on-insensitive@2.png")); }
+        background-image: url("../assets/switch-slider-on-insensitive.svg"); }
   switch slider {
     min-width: 1px;
     min-height: 1px;
     background-repeat: no-repeat;
     background-position: left center;
     background-color: transparent;
-    background-image: -gtk-scaled(url("../assets/switch-slider-off.svg"), url("../assets/switch-slider-off@2.png")); }
+    background-image: url("../assets/switch-slider-off.svg"); }
   row:selected switch:checked {
-    background-image: -gtk-scaled(url("../assets/switch-off.svg"), url("../assets/switch-off.svg")); }
+    background-image: url("../assets/switch-off.svg"); }
     row:selected switch:checked slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-on-selected.svg"), url("../assets/switch-slider-on-selected@2.png")); }
+      background-image: url("../assets/switch-slider-on-selected.svg"); }
   switch trough:active, switch trough:checked {
     background-color: #8fbcbb; }
     switch trough:active:backdrop, switch trough:checked:backdrop {
@@ -4690,20 +4690,20 @@ windowcontrols button.close, windowcontrols button.maximize, windowcontrols butt
     box-shadow: none;
     color: transparent; }
 windowcontrols button.close {
-  background-image: -gtk-scaled(url("../assets/close.png"), url("../assets/close@2.png")); }
+  background-image: url("../assets/close.png"); }
   windowcontrols button.close:hover, windowcontrols button.close:active {
-    background-image: -gtk-scaled(url("../assets/close_prelight.png"), url("../assets/close_prelight@2.png")); }
+    background-image: url("../assets/close_prelight.png"); }
 windowcontrols button.maximize {
-  background-image: -gtk-scaled(url("../assets/maximize.png"), url("../assets/maximize@2.png")); }
+  background-image: url("../assets/maximize.png"); }
   windowcontrols button.maximize:hover, windowcontrols button.maximize:active {
-    background-image: -gtk-scaled(url("../assets/maximize_prelight.png"), url("../assets/maximize_prelight@2.png")); }
+    background-image: url("../assets/maximize_prelight.png"); }
 windowcontrols button.minimize {
-  background-image: -gtk-scaled(url("../assets/min.png"), url("../assets/min@2.png")); }
+  background-image: url("../assets/min.png"); }
   windowcontrols button.minimize:hover, windowcontrols button.minimize:active {
-    background-image: -gtk-scaled(url("../assets/min_prelight.png"), url("../assets/min_prelight@2.png")); }
+    background-image: url("../assets/min_prelight.png"); }
 windowcontrols button:backdrop {
   -gtk-icon-shadow: none;
-  background-image: -gtk-scaled(url("../assets/close_unfocused.png"), url("../assets/close_unfocused@2.png")); }
+  background-image: url("../assets/close_unfocused.png"); }
 
 headerbar.selection-mode button.titlebutton,
 .titlebar.selection-mode button.titlebutton {

--- a/gtk-4.0/widgets/_checks-radios.scss
+++ b/gtk-4.0/widgets/_checks-radios.scss
@@ -13,11 +13,11 @@
                   (':disabled', '-unchecked-insensitive'),
                   (':disabled:backdrop', '-unchecked-insensitive') {
   check#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/checkbox#{$un}.png"),url("../assets/checkbox#{$un}@2.png")), -gtk-scaled(url("../assets/checkbox#{$un}-dark.png"),url("../assets/checkbox#{$un}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/checkbox#{$un}.png"), url("../assets/checkbox#{$un}-dark.png"));
     -gtk-icon-shadow: none;
   }
   radio#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/radio#{$un}.png"),url("../assets/radio#{$un}@2.png")), -gtk-scaled(url("../assets/radio#{$un}-dark.png"),url("../assets/radio#{$un}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/radio#{$un}.png"), url("../assets/radio#{$un}-dark.png"));
     -gtk-icon-shadow: none;
   }
 }
@@ -30,11 +30,11 @@
                   (':checked:disabled', '-checked-insensitive'),
                   (':checked:disabled:backdrop', '-checked-insensitive') {
   check#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/checkbox#{$ch}.png"),url("../assets/checkbox#{$ch}@2.png")), -gtk-scaled(url("../assets/checkbox#{$ch}-dark.png"),url("../assets/checkbox#{$ch}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/checkbox#{$ch}.png"), url("../assets/checkbox#{$ch}-dark.png"));
     -gtk-icon-shadow: none;
   }
   radio#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/radio#{$ch}.png"),url("../assets/radio#{$ch}@2.png")), -gtk-scaled(url("../assets/radio#{$ch}-dark.png"),url("../assets/radio#{$ch}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/radio#{$ch}.png"), url("../assets/radio#{$ch}-dark.png"));
     -gtk-icon-shadow: none;
     background: none;
   }
@@ -48,11 +48,11 @@
                   (':indeterminate:disabled', '-mixed-insensitive'),
                   (':indeterminate:disabled:backdrop', '-mixed-insensitive') {
   check#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/checkbox#{$mx}.png"),url("../assets/checkbox#{$mx}@2.png")), -gtk-scaled(url("../assets/checkbox#{$mx}.png"),url("../assets/checkbox#{$mx}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/checkbox#{$mx}.png"), url("../assets/checkbox#{$mx}.png"));
     -gtk-icon-shadow: none;
   }
   radio#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/radio#{$mx}.png"),url("../assets/radio#{$mx}@2.png")), -gtk-scaled(url("../assets/radio#{$mx}.png"),url("../assets/radio#{$mx}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/radio#{$mx}.png"), url("../assets/radio#{$mx}.png"));
     -gtk-icon-shadow: none;
   }
 }
@@ -65,11 +65,11 @@
                   (':disabled:selected', '-unchecked'),
                   (':disabled:backdrop:selected', '-unchecked') {
   check#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/checkbox#{$un}.png"),url("../assets/checkbox#{$un}@2.png")), -gtk-scaled(url("../assets/checkbox#{$un}-dark.png"),url("../assets/checkbox#{$un}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/checkbox#{$un}.png"), url("../assets/checkbox#{$un}-dark.png"));
     -gtk-icon-shadow: none;
   }
   radio#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/selected-radio#{$un}.png"),url("../assets/selected-radio#{$un}@2.png")), -gtk-scaled(url("../assets/selected-radio#{$un}-dark.png"),url("../assets/selected-radio#{$un}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/selected-radio#{$un}.png"), url("../assets/selected-radio#{$un}-dark.png"));
     -gtk-icon-shadow: none;
   }
 }
@@ -82,11 +82,11 @@
                   (':checked:disabled:selected', '-checked'),
                   (':checked:disabled:backdrop:selected', '-checked') {
   check#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/checkbox#{$ch}.png"),url("../assets/checkbox#{$ch}@2.png")), -gtk-scaled(url("../assets/checkbox#{$ch}-dark.png"),url("../assets/checkbox#{$ch}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/checkbox#{$ch}.png"), url("../assets/checkbox#{$ch}-dark.png"));
     -gtk-icon-shadow: none;
   }
   radio#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/selected-radio#{$ch}.png"),url("../assets/selected-radio#{$ch}@2.png")), -gtk-scaled(url("../assets/selected-radio#{$ch}-dark.png"),url("../assets/selected-radio#{$ch}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/selected-radio#{$ch}.png"), url("../assets/selected-radio#{$ch}-dark.png"));
     -gtk-icon-shadow: none;
   }
 }
@@ -100,11 +100,11 @@
                   (':indeterminate:disabled:selected', '-mixed'),
                   (':indeterminate:disabled:backdrop:selected', '-mixed') {
   check#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/selected-checkbox#{$mx}.png"),url("../assets/selected-checkbox#{$mx}@2.png")), -gtk-scaled(url("../assets/selected-checkbox#{$mx}.png"),url("../assets/selected-checkbox#{$mx}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/selected-checkbox#{$mx}.png"), url("../assets/selected-checkbox#{$mx}.png"));
     -gtk-icon-shadow: none;
   }
   radio#{$s}{
-    -gtk-icon-source: if($variant == 'light', -gtk-scaled(url("../assets/selected-radio#{$mx}.png"),url("../assets/selected-radio#{$mx}@2.png")), -gtk-scaled(url("../assets/selected-radio#{$mx}.png"),url("../assets/selected-radio#{$mx}@2.png")));
+    -gtk-icon-source: if($variant == 'light', url("../assets/selected-radio#{$mx}.png"), url("../assets/selected-radio#{$mx}.png"));
     -gtk-icon-shadow: none;
   }
 }
@@ -119,12 +119,12 @@
                   (':disabled:backdrop', '-unchecked-backdrop-insensitive') {
   .view.content-view check#{$s},
   .view.content-view.check#{$s}{
-    -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-checkbox#{$un}.png"),url("../assets/checkbox#{$un}@2.png"));
+    -gtk-icon-source: url("../assets/selection-mode-checkbox#{$un}.png");
     -gtk-icon-shadow: none;
   }
   .view.content-view radio#{$s},
   .view.content-view.radio#{$s}{
-    -gtk-icon-source: -gtk-scaled(url("../assets/selection-mode-radio#{$un}.png"),url("../assets/radio#{$un}@2.png"));
+    -gtk-icon-source: url("../assets/selection-mode-radio#{$un}.png");
     -gtk-icon-shadow: none;
   }
 }

--- a/gtk-4.0/widgets/_switches.scss
+++ b/gtk-4.0/widgets/_switches.scss
@@ -9,12 +9,12 @@ switch {
   background-size: 40px 24px;
   background-repeat: no-repeat;
   background-position: center center;
-  background-image: -gtk-scaled(url("../assets/switch-off.svg"),url("../assets/switch-off.svg"));
+  background-image: url("../assets/switch-off.svg");
 
   &:disabled {
-    background-image: -gtk-scaled(url("../assets/switch-insensitive.svg"),url("../assets/switch-insensitive.svg"));
+    background-image: url("../assets/switch-insensitive.svg");
     slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-insensitive.svg"),url("../assets/switch-slider-insensitive@2.png"));
+      background-image: url("../assets/switch-slider-insensitive.svg");
     }
   }
 
@@ -26,14 +26,14 @@ switch {
   }
   
   &:checked {
-    background-image: -gtk-scaled(url("../assets/switch-on.svg"),url("../assets/switch-on.svg"));
+    background-image: url("../assets/switch-on.svg");
     slider {
-      background-image: -gtk-scaled(url("../assets/switch-slider-on.svg"),url("../assets/switch-slider-on@2.png"));
+      background-image: url("../assets/switch-slider-on.svg");
     }
     &:disabled {
-      background-image: -gtk-scaled(url("../assets/switch-on-insensitive.svg"),url("../assets/switch-on-insensitive.svg"));
+      background-image: url("../assets/switch-on-insensitive.svg");
       slider {
-        background-image: -gtk-scaled(url("../assets/switch-slider-on-insensitive.svg"),url("../assets/switch-slider-on-insensitive@2.png"));
+        background-image: url("../assets/switch-slider-on-insensitive.svg");
       }
     }
   }
@@ -45,7 +45,7 @@ switch {
     background-repeat: no-repeat;
     background-position: left center;
     background-color: transparent;
-    background-image: -gtk-scaled(url("../assets/switch-slider-off.svg"),url("../assets/switch-slider-off@2.png"));
+    background-image: url("../assets/switch-slider-off.svg");
   }
 
   &:checked slider { }
@@ -55,9 +55,9 @@ switch {
 
   row:selected & {
     &:checked {
-      background-image: -gtk-scaled(url("../assets/switch-off.svg"),url("../assets/switch-off.svg"));
+      background-image: url("../assets/switch-off.svg");
       slider {
-        background-image: -gtk-scaled(url("../assets/switch-slider-on-selected.svg"),url("../assets/switch-slider-on-selected@2.png"));
+        background-image: url("../assets/switch-slider-on-selected.svg");
       }
     } 
   }

--- a/gtk-4.0/widgets/_touch-copy-paste.scss
+++ b/gtk-4.0/widgets/_touch-copy-paste.scss
@@ -13,22 +13,19 @@ cursor-handle {
                   (':active','-active') { //no need for insensitive and backdrop
     &.top#{$s}:dir(ltr), &.bottom#{$s}:dir(rtl) {
       $_url: 'assets/text-select-start#{$as}#{$asset_suffix}';
-      -gtk-icon-source: -gtk-scaled(url('#{$_url}.png'),
-                                    url('#{$_url}@2.png'));
+      -gtk-icon-source: url('#{$_url}.png');
       padding-left: 10px;
     }
 
     &.bottom#{$s}:dir(ltr), &.top#{$s}:dir(rtl) {
       $_url: 'assets/text-select-end#{$as}#{$asset_suffix}';
-      -gtk-icon-source: -gtk-scaled(url('#{$_url}.png'),
-                                    url('#{$_url}@2.png'));
+      -gtk-icon-source: url('#{$_url}.png');
       padding-right: 10px;
     }
 
     &.insertion-cursor#{$s}:dir(ltr), &.insertion-cursor#{$s}:dir(rtl) {
       $_url: 'assets/slider-horz-scale-has-marks-above#{$as}#{$asset_suffix}';
-      -gtk-icon-source: -gtk-scaled(url('#{$_url}.png'),
-                                    url('#{$_url}@2.png'));
+      -gtk-icon-source: url('#{$_url}.png');
     }
   }
 }

--- a/gtk-4.0/widgets/_windows.scss
+++ b/gtk-4.0/widgets/_windows.scss
@@ -98,21 +98,21 @@ windowcontrols {
     }
     
     &.close {
-      background-image: -gtk-scaled(url("../assets/close.png"),url("../assets/close@2.png"));
+      background-image: url("../assets/close.png");
       &:hover,&:active {
-        background-image: -gtk-scaled(url("../assets/close_prelight.png"),url("../assets/close_prelight@2.png"));
+        background-image: url("../assets/close_prelight.png");
       }
     }
     &.maximize {
-      background-image: -gtk-scaled(url("../assets/maximize.png"),url("../assets/maximize@2.png"));
+      background-image: url("../assets/maximize.png");
       &:hover,&:active {
-        background-image: -gtk-scaled(url("../assets/maximize_prelight.png"),url("../assets/maximize_prelight@2.png"));
+        background-image: url("../assets/maximize_prelight.png");
       }
     }
     &.minimize {
-      background-image: -gtk-scaled(url("../assets/min.png"),url("../assets/min@2.png"));
+      background-image: url("../assets/min.png");
       &:hover,&:active {
-        background-image: -gtk-scaled(url("../assets/min_prelight.png"),url("../assets/min_prelight@2.png"));
+        background-image: url("../assets/min_prelight.png");
       }
     }
   
@@ -124,7 +124,7 @@ windowcontrols {
   
     &:backdrop { 
       -gtk-icon-shadow: none; 
-      background-image: -gtk-scaled(url("../assets/close_unfocused.png"),url("../assets/close_unfocused@2.png"));
+      background-image: url("../assets/close_unfocused.png");
     }
   }
 }


### PR DESCRIPTION
## Problem

`-gtk-scaled()` was **removed in GTK 4.22** (Fedora 44 / GNOME 50 ships GTK 4.22.4). All `background-image` and `-gtk-icon-source` declarations that use `-gtk-scaled(url("X"), url("Y"))` are now silently dropped at parse time.

This causes:
- **Window control buttons** (close, minimize, maximize) to become completely **invisible** — the buttons are present and clickable but render as transparent because `color: transparent` is set and the background image is dropped.
- **Toggle switches**, **checkboxes**, and **radio buttons** to lose their PNG-based graphics.

This reproduces the issue reported in #347.

## Fix

Replace every occurrence of:
```css
-gtk-scaled(url("assets/foo.png"), url("assets/foo@2.png"))
```
with the 1× url() argument:
```css
url("assets/foo.png")
```

GTK 4 handles HiDPI scaling natively since GTK 4.0 and no longer needs (nor supports) the `-gtk-scaled()` hint. The PNG assets at 1× are loaded and scaled automatically by the compositor.

## Files changed

| File | Change |
|------|--------|
| `gtk-4.0/widgets/_windows.scss` | Window control buttons (close/min/max) |
| `gtk-4.0/widgets/_switches.scss` | Toggle switches |
| `gtk-4.0/widgets/_checks-radios.scss` | Checkboxes and radio buttons |
| `gtk-4.0/widgets/_touch-copy-paste.scss` | Touch selection handles |
| `gtk-4.0/gtk.css` | Compiled CSS (same fix applied) |
| `gtk-4.0/gtk-dark.css` | Compiled CSS dark variant (same fix applied) |

## Tested on

- Fedora 44, GNOME Shell 50.1, GTK 4.22.4, libadwaita 1.9.0